### PR TITLE
Allow optional RAG when generating flashcards

### DIFF
--- a/FlashcardsModule/flashcards.py
+++ b/FlashcardsModule/flashcards.py
@@ -60,7 +60,8 @@ class FlashcardSet:
         """
         Uses an LLM (optionally with RAG) to generate flashcards based on a topic prompt.
         When ``use_rag`` is True, additional context from your indexed documents is
-        fetched and prepended to the prompt.
+        fetched and prepended to the prompt. If a ``retriever`` was supplied and
+        ``use_rag`` is ``True``, it is used via ``RetrievalQA`` for generation.
         """
         llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=0.5, verbose=True)
 
@@ -103,8 +104,8 @@ class FlashcardSet:
         chain = RunnableSequence(branch, RunnableLambda(_build_prompt) | llm)
 
         try:
-            # if retriever provided, use RAG for richer context
-            if self.retriever:
+            # Use provided retriever only when RAG is enabled
+            if use_rag and self.retriever:
                 qa = RetrievalQA.from_chain_type(
                     llm=llm,
                     chain_type="stuff",
@@ -112,7 +113,11 @@ class FlashcardSet:
                 )
                 raw_output = qa.run(topic_prompt)
             else:
-                response = chain.invoke({"topic_prompt": topic_prompt, "language": language, "use_rag": use_rag})
+                response = chain.invoke({
+                    "topic_prompt": topic_prompt,
+                    "language": language,
+                    "use_rag": use_rag,
+                })
                 raw_output = response.content
 
             pairs = re.findall(r"Q:\s*(.+?)\nA:\s*(.+?)(?=\nQ:|\Z)", raw_output, re.DOTALL)


### PR DESCRIPTION
## Summary
- update docstring of `FlashcardSet.generate_from_prompt`
- only use `self.retriever` when `use_rag=True`
- otherwise run the normal chain with/without context based on `use_rag`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68763066f69083239f39c34ed5c677d6