### PR TITLE
Use optional RAG retriever in generators

### DIFF
--- a/CheatSheetModule/cheatsheet_generator.py
+++ b/CheatSheetModule/cheatsheet_generator.py
@@ -56,9 +56,14 @@ Respond in this language only: {language}
             Generated cheat sheet as string.
         """
         def _fetch_context(inputs):
-            rag = RAGHandler()
-            rag.load_vectorstore()
-            ctx = rag.get_context(inputs["input"], k=3)
+            """Retrieve context from the provided retriever or a temporary RAG handler."""
+            if self.retriever is not None:
+                docs = self.retriever.get_relevant_documents(inputs["input"])
+                ctx = "\n\n".join(doc.page_content for doc in docs)
+            else:
+                rag = RAGHandler()
+                rag.load_vectorstore()
+                ctx = rag.get_context(inputs["input"], k=3)
             return {"input": inputs["input"], "language": inputs["language"], "context": ctx}
 
         def _skip_context(inputs):

--- a/SummaryModule/summary_generator.py
+++ b/SummaryModule/summary_generator.py
@@ -64,9 +64,14 @@ Respond in {language}.
         lang = LanguageHandler.choose_or_detect(input_text) if language == "auto" else language
 
         def _fetch_context(inputs):
-            rag = RAGHandler()
-            rag.load_vectorstore()
-            ctx = rag.get_context(inputs["input"], k=3)
+            """Retrieve additional context using RAG if a retriever is provided."""
+            if self.retriever is not None:
+                docs = self.retriever.get_relevant_documents(inputs["input"])
+                ctx = "\n\n".join(doc.page_content for doc in docs)
+            else:
+                rag = RAGHandler()
+                rag.load_vectorstore()
+                ctx = rag.get_context(inputs["input"], k=3)
             inputs["input"] = f"{ctx}\n\n### Topic:\n{inputs['input']}"
             return inputs
 


### PR DESCRIPTION
## Summary
- allow passing in a retriever to `StudySummaryGenerator` and `CheatSheetGenerator`
- fall back to `RAGHandler` only when no retriever is provided

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68763068e160832394a30d23ba976a22