### PR TITLE
Share single retriever across modules

### DIFF
--- a/CheatSheetModule/cheatsheet_generator.py
+++ b/CheatSheetModule/cheatsheet_generator.py
@@ -42,7 +42,8 @@ Respond in this language only: {language}
         self,
         input_text: str,
         language: str = "en",
-        use_rag: bool = False
+        use_rag: bool = False,
+        retriever=None
     ) -> str:
         """
         Generate a cheat sheet; uses RAG if use_rag=True.
@@ -51,14 +52,21 @@ Respond in this language only: {language}
             input_text: topic or material for which to generate the cheat sheet
             language: language code for the output
             use_rag: if True, fetch additional context from your documents
+            retriever: optional external retriever to supply that context
 
         Returns:
             Generated cheat sheet as string.
         """
+        retriever = retriever or self.retriever
+
         def _fetch_context(inputs):
-            rag = RAGHandler()
-            rag.load_vectorstore()
-            ctx = rag.get_context(inputs["input"], k=3)
+            if retriever:
+                docs = retriever.get_relevant_documents(inputs["input"])
+                ctx = "\n\n".join([doc.page_content for doc in docs])
+            else:
+                rag = RAGHandler()
+                rag.load_vectorstore()
+                ctx = rag.get_context(inputs["input"], k=3)
             return {"input": inputs["input"], "language": inputs["language"], "context": ctx}
 
         def _skip_context(inputs):

--- a/FlashcardsModule/flashcards.py
+++ b/FlashcardsModule/flashcards.py
@@ -56,18 +56,24 @@ class FlashcardSet:
             except Exception as e:
                 print(f"⚠️ Error parsing block: {e}")
 
-    def generate_from_prompt(self, topic_prompt: str, language: str = "en", use_rag: bool = False):
+    def generate_from_prompt(self, topic_prompt: str, language: str = "en", use_rag: bool = False, retriever=None):
         """
         Uses an LLM (optionally with RAG) to generate flashcards based on a topic prompt.
         When ``use_rag`` is True, additional context from your indexed documents is
-        fetched and prepended to the prompt.
+        fetched and prepended to the prompt. An external ``retriever`` can be
+        provided to avoid creating a new :class:`RAGHandler`.
         """
         llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=0.5, verbose=True)
+        retriever = retriever or self.retriever
 
         def _fetch_context(inputs):
-            rag = RAGHandler()
-            rag.load_vectorstore()
-            ctx = rag.get_context(inputs["topic_prompt"], k=3)
+            if retriever:
+                docs = retriever.get_relevant_documents(inputs["topic_prompt"])
+                ctx = "\n\n".join([doc.page_content for doc in docs])
+            else:
+                rag = RAGHandler()
+                rag.load_vectorstore()
+                ctx = rag.get_context(inputs["topic_prompt"], k=3)
             return {**inputs, "context": ctx}
 
         def _skip_context(inputs):
@@ -104,11 +110,11 @@ class FlashcardSet:
 
         try:
             # if retriever provided, use RAG for richer context
-            if self.retriever:
+            if retriever:
                 qa = RetrievalQA.from_chain_type(
                     llm=llm,
                     chain_type="stuff",
-                    retriever=self.retriever
+                    retriever=retriever
                 )
                 raw_output = qa.run(topic_prompt)
             else:

--- a/QuizModule/quiz_operations.py
+++ b/QuizModule/quiz_operations.py
@@ -10,10 +10,11 @@ from LearningPlanModule.learning_plan import LearningPlan
 from tools.language_handler import LanguageHandler
 from RAGModule.rag import RAGHandler
 
-def generate_quiz(subject: str, language: str = "en", use_rag: bool = False):
+def generate_quiz(subject: str, language: str = "en", use_rag: bool = False, retriever=None):
     """
     Generates a quiz based on the provided subject using parallel chains.
-    If use_rag is True, fetches relevant documents for context via RAG.
+    If ``use_rag`` is True, optional ``retriever`` supplies context; otherwise a
+    new :class:`RAGHandler` is created.
     """
     try:
         llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=0.1, verbose=True)
@@ -21,9 +22,12 @@ def generate_quiz(subject: str, language: str = "en", use_rag: bool = False):
         # Optional RAG context fetch
         context = ""
         if use_rag:
-            rag = RAGHandler()
-            rag.load_vectorstore()
-            docs = rag.semantic_search(subject, k=3)
+            if retriever:
+                docs = retriever.get_relevant_documents(subject)
+            else:
+                rag = RAGHandler()
+                rag.load_vectorstore()
+                docs = rag.semantic_search(subject, k=3)
             context = "\n\n".join([doc.page_content for doc in docs])
             print(f"[RAG] Retrieved {len(docs)} documents for context.")
 
@@ -53,10 +57,12 @@ def generate_quiz(subject: str, language: str = "en", use_rag: bool = False):
         # Generate questions in parallel
         print("Generating questions for all topics...")
         if use_rag:
-            rag = RAGHandler()
-            rag.load_vectorstore()
-
-            context_chain = RunnableLambda(lambda inputs: rag.get_context(inputs["topic"], k=3))
+            if retriever:
+                context_chain = RunnableLambda(lambda inputs: "\n\n".join([doc.page_content for doc in retriever.get_relevant_documents(inputs["topic"])]))
+            else:
+                rag = RAGHandler()
+                rag.load_vectorstore()
+                context_chain = RunnableLambda(lambda inputs: rag.get_context(inputs["topic"], k=3))
             prompt_chain = RunnableLambda(
                 lambda inputs: generate_questions_prompt(inputs["topic"], language=language)
                     .format_prompt(topic=inputs["topic"])

--- a/SummaryModule/summary_generator.py
+++ b/SummaryModule/summary_generator.py
@@ -54,19 +54,26 @@ Respond in {language}.
         self,
         input_text: str,
         language: str = "en",
-        use_rag: bool = False
+        use_rag: bool = False,
+        retriever=None
     ) -> str:
         """
         Generate a detailed study summary using the configured LLM and prompt.
-        If ``use_rag`` is True, the generator first retrieves context from your
-        indexed documents and prepends it to the prompt.
+        If ``use_rag`` is True, an external ``retriever`` can be supplied for
+        context; otherwise a new :class:`RAGHandler` will be used.
         """
         lang = LanguageHandler.choose_or_detect(input_text) if language == "auto" else language
 
+        retriever = retriever or self.retriever
+
         def _fetch_context(inputs):
-            rag = RAGHandler()
-            rag.load_vectorstore()
-            ctx = rag.get_context(inputs["input"], k=3)
+            if retriever:
+                docs = retriever.get_relevant_documents(inputs["input"])
+                ctx = "\n\n".join([doc.page_content for doc in docs])
+            else:
+                rag = RAGHandler()
+                rag.load_vectorstore()
+                ctx = rag.get_context(inputs["input"], k=3)
             inputs["input"] = f"{ctx}\n\n### Topic:\n{inputs['input']}"
             return inputs
 

--- a/main.py
+++ b/main.py
@@ -85,7 +85,7 @@ def main_menu():
             language = LanguageHandler.choose_or_detect(subject)
             # pass retriever to quiz (RAG-enabled if available)
             use_rag = input("Use RAG to generate quiz topics? (y/N): ").strip().lower()=="y"
-            generate_quiz(subject, language=language, use_rag=use_rag)
+            generate_quiz(subject, language=language, use_rag=use_rag, retriever=retriever)
 
         elif choice == "3":
             print("\nSelect an option:")
@@ -96,7 +96,7 @@ def main_menu():
             if sub_choice == "1":
                 subject = input("Enter the subject for the quiz: ")
                 language = LanguageHandler.choose_or_detect(subject)
-                quiz_results = generate_quiz(subject, language=language)
+                quiz_results = generate_quiz(subject, language=language, retriever=retriever)
                 user_name = input("Enter your name: ")
                 generate_learning_plan_from_quiz(user_name, quiz_results, language)
             elif sub_choice == "2":
@@ -117,7 +117,7 @@ def main_menu():
             # pass retriever to flashcards
             flashcards = FlashcardSet(topic, retriever=retriever)
             use_rag = input("Enrich flashcards with your documents? (y/N): ").strip().lower()=="y"
-            flashcards.generate_from_prompt(topic_prompt=topic, language=language, use_rag=use_rag)
+            flashcards.generate_from_prompt(topic_prompt=topic, language=language, use_rag=use_rag, retriever=retriever)
             print(flashcards.to_dict_list())
             flashcards.save_to_file()
 
@@ -131,9 +131,9 @@ def main_menu():
             topic = input("Enter the topic or material for TL;DR summary: ")
             language = LanguageHandler.choose_or_detect(topic)
             # pass retriever to summary
-            summarizer = StudySummaryGenerator()
+            summarizer = StudySummaryGenerator(retriever=retriever)
             use_rag = input("Enrich summary with your documents? (y/N): ").strip().lower()=="y"
-            summary = summarizer.generate_summary(topic, language=language, use_rag=use_rag)
+            summary = summarizer.generate_summary(topic, language=language, use_rag=use_rag, retriever=retriever)
             print("\n📘 Summary:\n")
             print(summary)
 
@@ -143,7 +143,7 @@ def main_menu():
             # pass retriever to cheat sheet generator
             generator = CheatSheetGenerator(retriever=retriever)
             use_rag = input("Enrich cheat sheet with your documents? (y/N): ").strip().lower()=="y"
-            cheatsheet = generator.generate_cheatsheet(topic, language=language, use_rag=use_rag)
+            cheatsheet = generator.generate_cheatsheet(topic, language=language, use_rag=use_rag, retriever=retriever)
             print("\n📄 Cheat Sheet:\n")
             print(cheatsheet)
 


### PR DESCRIPTION
## Summary
- create RAG handler once in `main_menu` and obtain retriever
- pass the same retriever to quiz, summary, cheat‑sheet and flashcards
- allow modules to accept external retriever instead of creating new ones

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6876306816448323b9597346ac94ecef