### PR TITLE
Use provided retriever in RAG-enabled generators

### DIFF
--- a/CheatSheetModule/cheatsheet_generator.py
+++ b/CheatSheetModule/cheatsheet_generator.py
@@ -56,10 +56,18 @@ Respond in this language only: {language}
             Generated cheat sheet as string.
         """
         def _fetch_context(inputs):
-            rag = RAGHandler()
-            rag.load_vectorstore()
-            ctx = rag.get_context(inputs["input"], k=3)
-            return {"input": inputs["input"], "language": inputs["language"], "context": ctx}
+            if self.retriever:
+                docs = self.retriever.get_relevant_documents(inputs["input"])
+                ctx = "\n\n".join(doc.page_content for doc in docs)
+            else:
+                rag = RAGHandler()
+                rag.load_vectorstore()
+                ctx = rag.get_context(inputs["input"], k=3)
+            return {
+                "input": inputs["input"],
+                "language": inputs["language"],
+                "context": ctx,
+            }
 
         def _skip_context(inputs):
             return {"input": inputs["input"], "language": inputs["language"], "context": ""}

--- a/SummaryModule/summary_generator.py
+++ b/SummaryModule/summary_generator.py
@@ -64,9 +64,13 @@ Respond in {language}.
         lang = LanguageHandler.choose_or_detect(input_text) if language == "auto" else language
 
         def _fetch_context(inputs):
-            rag = RAGHandler()
-            rag.load_vectorstore()
-            ctx = rag.get_context(inputs["input"], k=3)
+            if self.retriever:
+                docs = self.retriever.get_relevant_documents(inputs["input"])
+                ctx = "\n\n".join(doc.page_content for doc in docs)
+            else:
+                rag = RAGHandler()
+                rag.load_vectorstore()
+                ctx = rag.get_context(inputs["input"], k=3)
             inputs["input"] = f"{ctx}\n\n### Topic:\n{inputs['input']}"
             return inputs
 


### PR DESCRIPTION
## Summary
- wire optional retriever into `StudySummaryGenerator` and `CheatSheetGenerator`
- fall back to creating a `RAGHandler` only when no retriever is provided

## Testing
- `pip install -q -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6876306ff528832388bada0a2cea9b7d