### PR TITLE
Fix RAG condition in flashcard generation

### DIFF
--- a/FlashcardsModule/flashcards.py
+++ b/FlashcardsModule/flashcards.py
@@ -109,8 +109,8 @@ class FlashcardSet:
         chain = RunnableSequence(branch, RunnableLambda(_build_prompt) | llm)
 
         try:
-            # Use provided retriever only when RAG is enabled
-            if use_rag and self.retriever:
+            # Use any available retriever only when RAG is enabled
+            if use_rag and retriever:
                 qa = RetrievalQA.from_chain_type(
                     llm=llm,
                     chain_type="stuff",


### PR DESCRIPTION
## Summary
- use any available retriever when generating flashcards with RAG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877820e83488323a2bfa59e9d35fbf0