### PR TITLE
Fix division by zero when no quiz topics

### DIFF
--- a/QuizModule/quiz_operations.py
+++ b/QuizModule/quiz_operations.py
@@ -48,6 +48,11 @@ def generate_quiz(subject: str, language: str = "en", use_rag: bool = False):
         max_questions = 20
         max_topics = min(len(topics), 5)
         topics = topics[:max_topics]
+
+        if max_topics == 0:
+            print("No quiz topics generated.")
+            return {}
+
         questions_per_topic = max_questions // max_topics
 
         # Generate questions in parallel


### PR DESCRIPTION
## Summary
- guard against zero topics when generating a quiz
- run `black --check` as linter

## Testing
- `black --check QuizModule/quiz_operations.py`

------
https://chatgpt.com/codex/tasks/task_e_687607432a8483238e821a48b0ec5f0e