### PR TITLE
Add default Gradio launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,23 +38,29 @@ OPENAI_API_KEY=your-key-here
 ## Usage
 
 ### CLI
-Run the interactive console menu:
+Run the interactive console menu (optional):
+
+```bash
+python main.py --cli
+```
+
+The menu lets you chat with the assistant, generate quizzes, summaries, flashcards and learning plans.
+If RAG documents are indexed (see `RAGModule`), some tools can enrich answers with your own files.
+
+### Gradio Frontend
+The application now launches the Gradio interface by default:
 
 ```bash
 python main.py
 ```
 
-The menu lets you chat with the assistant, generate quizzes, summaries, flashcards and learning plans.  
-If RAG documents are indexed (see `RAGModule`), some tools can enrich answers with your own files.
-
-### Gradio Frontend
-A minimal chat UI is provided using Gradio.  Start it with:
+You can also run the standalone frontend directly with:
 
 ```bash
 python frontend_service/main.py
 ```
 
-The frontend imports the same agent used by the CLI so you get identical behaviour in the browser.
+Both entry points import the same agent used by the optional CLI so you get identical behaviour in the browser.
 
 ## Project Structure
 - `AgentModule/` – creation of the LangChain agent and reusable tools

--- a/frontend_service/__init__.py
+++ b/frontend_service/__init__.py
@@ -1,1 +1,2 @@
 # Frontend service package
+from .interface import launch_gradio

--- a/frontend_service/interface.py
+++ b/frontend_service/interface.py
@@ -1,0 +1,59 @@
+import io
+from contextlib import redirect_stdout
+import gradio as gr
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from AgentModule import create_agent
+
+agent = create_agent()
+
+CSS = """
+* {
+  font-family: 'Segoe UI', Tahoma, sans-serif;
+}
+#chatbot .message.user {
+  background-color: #e6f3ff;
+  border-radius: 8px;
+}
+#chatbot .message.bot {
+  background-color: #f0f0f0;
+  border-radius: 8px;
+}
+"""
+
+
+def respond(message: str, history: list[tuple[str, str]]) -> tuple[list[tuple[str, str]], str]:
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        result = agent.invoke({"input": message})["output"]
+    history = history + [(message, result)]
+    logs = buffer.getvalue()
+    return history, logs
+
+
+def build_interface() -> gr.Blocks:
+    with gr.Blocks(css=CSS, theme=gr.themes.Soft()) as demo:
+        gr.Markdown("# EduGen Chat", elem_id="title")
+        chatbot = gr.Chatbot(elem_id="chatbot")
+        with gr.Row():
+            msg = gr.Textbox(placeholder="Type your message and press enter...", container=False)
+            send = gr.Button("Send", variant="primary")
+            clear = gr.Button("Clear")
+        logs = gr.Textbox(label="Terminal output", lines=8)
+
+        def clear_history():
+            return [], ""
+
+        msg.submit(respond, [msg, chatbot], [chatbot, logs])
+        send.click(respond, [msg, chatbot], [chatbot, logs])
+        clear.click(clear_history, None, [chatbot, logs])
+
+    return demo
+
+
+def launch_gradio() -> None:
+    demo = build_interface()
+    demo.queue()
+    demo.launch()

--- a/frontend_service/main.py
+++ b/frontend_service/main.py
@@ -1,63 +1,8 @@
-import io
-from contextlib import redirect_stdout
-
-import gradio as gr
-import os
-import sys
-
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-from AgentModule import create_agent
-
-agent = create_agent()
-
-CSS = """
-* {
-  font-family: 'Segoe UI', Tahoma, sans-serif;
-}
-#chatbot .message.user {
-  background-color: #e6f3ff;
-  border-radius: 8px;
-}
-#chatbot .message.bot {
-  background-color: #f0f0f0;
-  border-radius: 8px;
-}
-"""
-
-
-def respond(message: str, history: list[tuple[str, str]]) -> tuple[list[tuple[str, str]], str]:
-    buffer = io.StringIO()
-    with redirect_stdout(buffer):
-        result = agent.invoke({"input": message})["output"]
-    history = history + [(message, result)]
-    logs = buffer.getvalue()
-    return history, logs
-
-
-def build_interface() -> gr.Blocks:
-    with gr.Blocks(css=CSS, theme=gr.themes.Soft()) as demo:
-        gr.Markdown("# EduGen Chat", elem_id="title")
-        chatbot = gr.Chatbot(elem_id="chatbot")
-        with gr.Row():
-            msg = gr.Textbox(placeholder="Type your message and press enter...", container=False)
-            send = gr.Button("Send", variant="primary")
-            clear = gr.Button("Clear")
-        logs = gr.Textbox(label="Terminal output", lines=8)
-
-        def clear_history():
-            return [], ""
-
-        msg.submit(respond, [msg, chatbot], [chatbot, logs])
-        send.click(respond, [msg, chatbot], [chatbot, logs])
-        clear.click(clear_history, None, [chatbot, logs])
-
-    return demo
+from .interface import launch_gradio
 
 
 def main() -> None:
-    demo = build_interface()
-    demo.queue()
-    demo.launch()
+    launch_gradio()
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ from SummaryModule import StudySummaryGenerator
 from FlashcardsModule import FlashcardSet
 from CheatSheetModule import CheatSheetGenerator
 from AgentModule import create_agent
+from frontend_service import launch_gradio
 from tools.auto_answer import auto_answer
 from tools.language_handler import LanguageHandler
 from RAGModule import RAGHandler
@@ -185,4 +186,8 @@ def main_menu():
             print("Invalid choice. Please try again.")
 
 if __name__ == "__main__":
-    main_menu()
+    import sys
+    if len(sys.argv) > 1 and sys.argv[1] == "--cli":
+        main_menu()
+    else:
+        launch_gradio()


### PR DESCRIPTION
## Summary
- launch the Gradio chat UI when running `main.py`
- keep the old console menu under `--cli`
- update README usage instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68815c2e555c83239eaa7e6c4f7added