### PR TITLE
Update Gradio and add FastAPI dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,4 +34,6 @@ python-magic-bin>=0.4.14; platform_system == "Windows"
 wikipedia
 nltk
 
-gradio==4.24.0
+fastapi>=0.111
+starlette>=0.32
+gradio>=4.44.1


### PR DESCRIPTION
## Summary
- update `gradio` version and add `fastapi` and `starlette`
- verify frontend starts on Python 3.10

## Testing
- `pip install -r requirements.txt`
- `python frontend_service/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68815c304f648323bf4aa1e02ad857e9