### PR TITLE
Fix Gradio startup

### DIFF
--- a/frontend_service/interface.py
+++ b/frontend_service/interface.py
@@ -36,7 +36,7 @@ def respond(message: str, history: list[tuple[str, str]]) -> tuple[list[tuple[st
 def build_interface() -> gr.Blocks:
     with gr.Blocks(css=CSS, theme=gr.themes.Soft()) as demo:
         gr.Markdown("# EduGen Chat", elem_id="title")
-        chatbot = gr.Chatbot(elem_id="chatbot")
+        chatbot = gr.Chatbot(elem_id="chatbot", type="messages")
         with gr.Row():
             msg = gr.Textbox(placeholder="Type your message and press enter...", container=False)
             send = gr.Button("Send", variant="primary")

--- a/frontend_service/main.py
+++ b/frontend_service/main.py
@@ -1,4 +1,12 @@
-from .interface import launch_gradio
+"""Entry point for launching the Gradio frontend."""
+
+import os
+import sys
+
+# Ensure the repository root is on the path when running as a script
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from frontend_service.interface import launch_gradio
 
 
 def main() -> None:

--- a/frontend_service/main.py
+++ b/frontend_service/main.py
@@ -2,9 +2,13 @@
 
 import os
 import sys
+from dotenv import load_dotenv
 
 # Ensure the repository root is on the path when running as a script
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Load environment variables if running directly
+load_dotenv(os.path.join(os.path.dirname(__file__), "..", ".env"))
 
 from frontend_service.interface import launch_gradio
 

--- a/main.py
+++ b/main.py
@@ -1,4 +1,13 @@
+"""CLI and Gradio entry point for EduGen."""
+
+import os
 from dotenv import load_dotenv
+
+# Load environment variables from .env before importing modules that require
+# them (e.g. OpenAI API key for ChatOpenAI).
+dotenv_path = os.path.join(os.path.dirname(__file__), ".env")
+load_dotenv(dotenv_path)
+
 from QuizModule import generate_quiz, generate_learning_plan_from_quiz
 from LearningPlanModule import LearningPlan
 from SummaryModule import StudySummaryGenerator
@@ -9,13 +18,8 @@ from frontend_service import launch_gradio
 from tools.auto_answer import auto_answer
 from tools.language_handler import LanguageHandler
 from RAGModule import RAGHandler
-import os
 import warnings
 from langchain_core._api import LangChainDeprecationWarning
-
-# Load environment variables from .env
-dotenv_path = os.path.join(os.path.dirname(__file__), '.env')
-load_dotenv(dotenv_path)
 
 warnings.filterwarnings(
     "ignore",


### PR DESCRIPTION
## Summary
- make `frontend_service/main.py` runnable as a script by ensuring the repo root is on `sys.path`
- silence deprecated warning by specifying `type="messages"` for the Gradio `Chatbot`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884a096e54883239648417cb7f1da68