### PR TITLE
Fix loading empty vector store

### DIFF
--- a/RAGModule/rag.py
+++ b/RAGModule/rag.py
@@ -124,10 +124,23 @@ class RAGHandler:
         """
         self._init_embeddings()
         if self.vectordb is None:
-            self.vectordb = Chroma(
-                embedding_function=self.embeddings,
-                persist_directory=self.persist_dir
-            )
+            db_path = Path(self.persist_dir) / "chroma.sqlite3"
+
+            # Attempt to load existing DB if it exists
+            if db_path.exists():
+                self.vectordb = Chroma(
+                    embedding_function=self.embeddings,
+                    persist_directory=self.persist_dir,
+                )
+
+                try:
+                    # If no embeddings are stored, rebuild
+                    if self.vectordb._collection.count() == 0:
+                        self.vectordb = self.build_vectorstore()
+                except Exception:
+                    self.vectordb = self.build_vectorstore()
+            else:
+                self.vectordb = self.build_vectorstore()
         return self.vectordb
 
     def semantic_search(self, query: str, k: int = 3) -> List[Document]:


### PR DESCRIPTION
## Summary
- update `RAGHandler.load_vectorstore` to check for an existing DB and rebuild if empty

## Testing
- `python -m py_compile RAGModule/rag.py`
- *(failed to run full runtime tests due to missing OpenAI API access and network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_688514207f0c83239012a50811f3ae69