### PR TITLE
Add LLM fallback for failed tool responses

### DIFF
--- a/AgentModule/edu_agent.py
+++ b/AgentModule/edu_agent.py
@@ -50,12 +50,33 @@ def create_agent(model_name: str = "gpt-3.5-turbo") -> AgentExecutor:
     return AgentExecutor(agent=agent, tools=tools, verbose=True)
 
 
-def run_agent(question: str) -> str:
-    """Run the default agent on a question and return the answer."""
-    executor = create_agent()
+def run_agent(question: str, executor: AgentExecutor | None = None) -> str:
+    """Run the default agent on a question and return the answer.
+
+    If the agent cannot provide a useful response (e.g. tool errors), the
+    question is answered directly by the LLM as a fallback.
+    """
+    executor = executor or create_agent()
     from tools.language_handler import LanguageHandler
+
     lang = LanguageHandler.choose_or_detect(question)
-    result = executor.invoke({"input": question, "language": lang})
-    output = result["output"]
+    try:
+        result = executor.invoke({"input": question, "language": lang})
+        output = result["output"]
+    except Exception as e:  # pragma: no cover - agent execution errors
+        output = f"Agent error: {e}"
+
+    def _needs_fallback(text: str) -> bool:
+        markers = ["error", "not found", "couldn't"]
+        text = text.lower()
+        return any(m in text for m in markers)
+
+    if _needs_fallback(output):
+        llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=0)
+        try:
+            output = llm.invoke(question)
+        except Exception as e:  # pragma: no cover - API errors
+            output = f"LLM error: {e}"
+
     output = LanguageHandler.ensure_language(output, lang)
     return output

--- a/frontend_service/interface.py
+++ b/frontend_service/interface.py
@@ -10,14 +10,19 @@ import gradio as gr
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from AgentModule import create_agent
-from QuizModule import generate_quiz, generate_learning_plan_from_quiz, prepare_quiz_questions
+from AgentModule.edu_agent import run_agent
+from QuizModule import (
+    generate_quiz,
+    generate_learning_plan_from_quiz,
+    prepare_quiz_questions,
+)
 from LearningPlanModule import LearningPlan
 from SummaryModule import StudySummaryGenerator
 from FlashcardsModule import FlashcardSet
 from CheatSheetModule import CheatSheetGenerator
 from tools.language_handler import LanguageHandler
 
-dotenv_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '.env'))
+dotenv_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".env"))
 load_dotenv(dotenv_path)
 
 warnings.filterwarnings(
@@ -49,11 +54,13 @@ CSS = """
 """
 
 
-def respond(message: str, history: list[tuple[str, str]]) -> tuple[list[tuple[str, str]], str]:
+def respond(
+    message: str, history: list[tuple[str, str]]
+) -> tuple[list[tuple[str, str]], str]:
     language = LanguageHandler.choose_or_detect(message)
     buffer = io.StringIO()
     with redirect_stdout(buffer):
-        result = agent.invoke({"input": message, "language": language})["output"]
+        result = run_agent(message, executor=agent)
         result = LanguageHandler.ensure_language(result, language)
     history = history + [(message, result)]
     logs = buffer.getvalue()
@@ -122,9 +129,13 @@ def _compile_results(state: dict) -> str:
         lines.append(f"{topic}: {corr}/{tot} ({perc:.2f}%)")
         total_questions += tot
     if lines:
-        overall = sum((corr / tot) * 100 if tot else 0 for corr, tot in state["scores"].values())
+        overall = sum(
+            (corr / tot) * 100 if tot else 0 for corr, tot in state["scores"].values()
+        )
         overall /= len(state["scores"])
-        lines.append(f"\nOverall Score: {total_correct}/{total_questions} ({overall:.2f}%)")
+        lines.append(
+            f"\nOverall Score: {total_correct}/{total_questions} ({overall:.2f}%)"
+        )
     return "\n".join(lines)
 
 
@@ -148,7 +159,9 @@ def run_flashcards_generate(topic: str, use_rag: bool) -> tuple[list[dict], str]
     flashcards = FlashcardSet(topic)
     buffer = io.StringIO()
     with redirect_stdout(buffer):
-        flashcards.generate_from_prompt(topic_prompt=topic, language=language, use_rag=use_rag)
+        flashcards.generate_from_prompt(
+            topic_prompt=topic, language=language, use_rag=use_rag
+        )
         flashcards.save_to_file()
     return flashcards.to_dict_list(), buffer.getvalue()
 
@@ -198,7 +211,10 @@ def build_interface() -> gr.Blocks:
             with gr.TabItem("Chat with the bot"):
                 chatbot = gr.Chatbot(elem_id="chatbot")
                 with gr.Row():
-                    msg = gr.Textbox(placeholder="Type your message and press enter...", container=False)
+                    msg = gr.Textbox(
+                        placeholder="Type your message and press enter...",
+                        container=False,
+                    )
                     send = gr.Button("Send", variant="primary")
                     clear = gr.Button("Clear")
                 logs = gr.Textbox(label="Terminal output", lines=8)
@@ -224,11 +240,31 @@ def build_interface() -> gr.Blocks:
                 quiz_result = gr.Markdown()
                 quiz_state = gr.State()
 
-                start_btn.click(start_quiz, [quiz_subject, quiz_rag], [quiz_question, quiz_state, quiz_result])
-                btn_a.click(lambda st: answer_quiz("a", st), quiz_state, [quiz_question, quiz_state, quiz_result])
-                btn_b.click(lambda st: answer_quiz("b", st), quiz_state, [quiz_question, quiz_state, quiz_result])
-                btn_c.click(lambda st: answer_quiz("c", st), quiz_state, [quiz_question, quiz_state, quiz_result])
-                btn_d.click(lambda st: answer_quiz("d", st), quiz_state, [quiz_question, quiz_state, quiz_result])
+                start_btn.click(
+                    start_quiz,
+                    [quiz_subject, quiz_rag],
+                    [quiz_question, quiz_state, quiz_result],
+                )
+                btn_a.click(
+                    lambda st: answer_quiz("a", st),
+                    quiz_state,
+                    [quiz_question, quiz_state, quiz_result],
+                )
+                btn_b.click(
+                    lambda st: answer_quiz("b", st),
+                    quiz_state,
+                    [quiz_question, quiz_state, quiz_result],
+                )
+                btn_c.click(
+                    lambda st: answer_quiz("c", st),
+                    quiz_state,
+                    [quiz_question, quiz_state, quiz_result],
+                )
+                btn_d.click(
+                    lambda st: answer_quiz("d", st),
+                    quiz_state,
+                    [quiz_question, quiz_state, quiz_result],
+                )
 
             # Learning plan tab
             with gr.TabItem("Learning plan"):
@@ -236,7 +272,9 @@ def build_interface() -> gr.Blocks:
                 plan_goals = gr.Textbox(label="Learning goals (semicolon separated)")
                 plan_btn = gr.Button("Generate Plan")
                 plan_output = gr.Textbox(label="Plan Output", lines=10)
-                plan_btn.click(run_learning_plan_interface, [plan_name, plan_goals], plan_output)
+                plan_btn.click(
+                    run_learning_plan_interface, [plan_name, plan_goals], plan_output
+                )
 
             # Flashcards tab
             with gr.TabItem("Flashcards"):
@@ -246,7 +284,9 @@ def build_interface() -> gr.Blocks:
                     fc_gen_btn = gr.Button("Generate")
                     fc_cards = gr.JSON(label="Flashcards")
                     fc_logs = gr.Textbox(label="Logs", lines=4)
-                    fc_gen_btn.click(run_flashcards_generate, [fc_topic, fc_rag], [fc_cards, fc_logs])
+                    fc_gen_btn.click(
+                        run_flashcards_generate, [fc_topic, fc_rag], [fc_cards, fc_logs]
+                    )
 
                 with gr.Accordion("Review flashcards", open=False):
                     fc_path = gr.Textbox(label="Path to flashcards JSON")

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ from SummaryModule import StudySummaryGenerator
 from FlashcardsModule import FlashcardSet
 from CheatSheetModule import CheatSheetGenerator
 from AgentModule import create_agent
+from AgentModule.edu_agent import run_agent
 from frontend_service import launch_gradio
 from tools.auto_answer import auto_answer
 from tools.language_handler import LanguageHandler
@@ -14,7 +15,7 @@ import warnings
 from langchain_core._api import LangChainDeprecationWarning
 
 # Load environment variables from .env
-dotenv_path = os.path.join(os.path.dirname(__file__), '.env')
+dotenv_path = os.path.join(os.path.dirname(__file__), ".env")
 load_dotenv(dotenv_path)
 
 warnings.filterwarnings(
@@ -35,12 +36,14 @@ def prompt_input(prompt: str) -> str:
         return prompt_input(prompt)
     return user
 
+
 def chat_with_bot():
     """Chat with the assistant. Optionally use RAG for document context."""
     try:
-        use_rag = prompt_input(
-            "Enrich answers with your documents? (y/N): "
-        ).strip().lower() == "y"
+        use_rag = (
+            prompt_input("Enrich answers with your documents? (y/N): ").strip().lower()
+            == "y"
+        )
 
         chat_history = []
 
@@ -63,7 +66,7 @@ def chat_with_bot():
                 # Pre-load vector store so the agent can query documents
                 pass
             language = LanguageHandler.choose_or_detect(query)
-            answer = _agent.invoke({"input": query, "language": language})["output"]
+            answer = run_agent(query, executor=_agent)
             answer = LanguageHandler.ensure_language(answer, language)
             print(f"AI: {answer}")
             chat_history.append((query, answer))
@@ -75,6 +78,7 @@ def chat_with_bot():
 
     except Exception as e:
         print(f"An error occurred while chatting with the bot: {e}")
+
 
 def main_menu():
     """
@@ -103,7 +107,9 @@ def main_menu():
         choice = prompt_input("Enter the number of your choice: ").strip()
 
         if choice == "0":
-            print("Enter your preferred language code (e.g. en, pl, de, fr) or 'auto' to detect automatically each time:")
+            print(
+                "Enter your preferred language code (e.g. en, pl, de, fr) or 'auto' to detect automatically each time:"
+            )
             lang = prompt_input("Language: ").strip()
             LanguageHandler.set_language(lang)
             print(f"Language set to: {lang}")
@@ -115,8 +121,13 @@ def main_menu():
             subject = prompt_input("Enter the subject for the quiz: ")
             language = LanguageHandler.choose_or_detect(subject)
             # pass retriever to quiz (RAG-enabled if available)
-            use_rag = prompt_input("Use RAG to generate quiz topics? (y/N): ").strip().lower()=="y"
-            generate_quiz(subject, language=language, use_rag=use_rag, retriever=retriever)
+            use_rag = (
+                prompt_input("Use RAG to generate quiz topics? (y/N): ").strip().lower()
+                == "y"
+            )
+            generate_quiz(
+                subject, language=language, use_rag=use_rag, retriever=retriever
+            )
 
         elif choice == "3":
             print("\nSelect an option:")
@@ -127,15 +138,26 @@ def main_menu():
             if sub_choice == "1":
                 subject = prompt_input("Enter the subject for the quiz: ")
                 language = LanguageHandler.choose_or_detect(subject)
-                use_rag = prompt_input("Use RAG to generate quiz topics? (y/N): ").strip().lower()=="y"
-                quiz_results = generate_quiz(subject, language=language, use_rag=use_rag, retriever=retriever)
+                use_rag = (
+                    prompt_input("Use RAG to generate quiz topics? (y/N): ")
+                    .strip()
+                    .lower()
+                    == "y"
+                )
+                quiz_results = generate_quiz(
+                    subject, language=language, use_rag=use_rag, retriever=retriever
+                )
                 user_name = prompt_input("Enter your name: ")
                 generate_learning_plan_from_quiz(user_name, quiz_results, language)
             elif sub_choice == "2":
                 user_name = prompt_input("Enter your name: ")  # TODO: consider deleting
-                goals_input = prompt_input("Enter your learning goals (comma-separated): ")
+                goals_input = prompt_input(
+                    "Enter your learning goals (comma-separated): "
+                )
                 language = LanguageHandler.choose_or_detect(goals_input)
-                user_input = {"goals": [goal.strip() for goal in goals_input.split(",")]}
+                user_input = {
+                    "goals": [goal.strip() for goal in goals_input.split(",")]
+                }
                 plan = LearningPlan(user_name=user_name, user_language=language)
                 plan.generate_plan_from_prompt(user_input)
                 plan.display_plan()
@@ -148,8 +170,18 @@ def main_menu():
             language = LanguageHandler.choose_or_detect(topic)
             # pass retriever to flashcards
             flashcards = FlashcardSet(topic, retriever=retriever)
-            use_rag = prompt_input("Enrich flashcards with your documents? (y/N): ").strip().lower()=="y"
-            flashcards.generate_from_prompt(topic_prompt=topic, language=language, use_rag=use_rag, retriever=retriever)
+            use_rag = (
+                prompt_input("Enrich flashcards with your documents? (y/N): ")
+                .strip()
+                .lower()
+                == "y"
+            )
+            flashcards.generate_from_prompt(
+                topic_prompt=topic,
+                language=language,
+                use_rag=use_rag,
+                retriever=retriever,
+            )
             print(flashcards.to_dict_list())
             flashcards.save_to_file()
 
@@ -164,8 +196,15 @@ def main_menu():
             language = LanguageHandler.choose_or_detect(topic)
             # pass retriever to summary
             summarizer = StudySummaryGenerator(retriever=retriever)
-            use_rag = prompt_input("Enrich summary with your documents? (y/N): ").strip().lower()=="y"
-            summary = summarizer.generate_summary(topic, language=language, use_rag=use_rag, retriever=retriever)
+            use_rag = (
+                prompt_input("Enrich summary with your documents? (y/N): ")
+                .strip()
+                .lower()
+                == "y"
+            )
+            summary = summarizer.generate_summary(
+                topic, language=language, use_rag=use_rag, retriever=retriever
+            )
             print("\n📘 Summary:\n")
             print(summary)
 
@@ -174,11 +213,17 @@ def main_menu():
             language = LanguageHandler.choose_or_detect(topic)
             # pass retriever to cheat sheet generator
             generator = CheatSheetGenerator(retriever=retriever)
-            use_rag = prompt_input("Enrich cheat sheet with your documents? (y/N): ").strip().lower()=="y"
-            cheatsheet = generator.generate_cheatsheet(topic, language=language, use_rag=use_rag, retriever=retriever)
+            use_rag = (
+                prompt_input("Enrich cheat sheet with your documents? (y/N): ")
+                .strip()
+                .lower()
+                == "y"
+            )
+            cheatsheet = generator.generate_cheatsheet(
+                topic, language=language, use_rag=use_rag, retriever=retriever
+            )
             print("\n📄 Cheat Sheet:\n")
             print(cheatsheet)
-
 
         elif choice in ("8", "q", "quit"):
             print("Goodbye!")
@@ -187,8 +232,10 @@ def main_menu():
         else:
             print("Invalid choice. Please try again.")
 
+
 if __name__ == "__main__":
     import sys
+
     if len(sys.argv) > 1 and sys.argv[1] == "--cli":
         main_menu()
     else:

--- a/tools/auto_answer.py
+++ b/tools/auto_answer.py
@@ -1,8 +1,9 @@
 """Automatic question answering helper."""
+
 from __future__ import annotations
 
 from typing import Optional
-from AgentModule.edu_agent import create_agent, AgentExecutor
+from AgentModule.edu_agent import create_agent, run_agent, AgentExecutor
 from tools.language_handler import LanguageHandler
 
 
@@ -16,8 +17,8 @@ def auto_answer(text: str, agent: Optional[AgentExecutor] = None) -> bool:
     if text.strip().endswith("?"):
         agent = agent or create_agent()
         language = LanguageHandler.choose_or_detect(text)
-        answer = agent.invoke({"input": text, "language": language})["output"]
+        answer = run_agent(text, executor=agent)
         answer = LanguageHandler.ensure_language(answer, language)
-        print(f"\n\U0001F916 Agent Answer:\n{answer}\n")
+        print(f"\n\U0001f916 Agent Answer:\n{answer}\n")
         return True
     return False


### PR DESCRIPTION
## Summary
- ensure `run_agent` can fall back to a plain LLM call when tools fail
- use `run_agent` in auto answer, CLI chat and Gradio interface

## Testing
- `black AgentModule/edu_agent.py tools/auto_answer.py frontend_service/interface.py main.py`
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_688519ec61e08323a090ec874fbb6fbe