### PR TITLE
Add flashcard generation from quiz

### DIFF
--- a/FlashcardsModule/flashcards.py
+++ b/FlashcardsModule/flashcards.py
@@ -40,20 +40,25 @@ class FlashcardSet:
         self.flashcards.append(flashcard)
 
     def generate_from_quiz_text(self, raw_text: str):
-        """
-        Parses quiz-style text and extracts flashcards from question blocks.
-        """
+        """Parse quiz-style text and extract flashcards from question blocks."""
         blocks = raw_text.strip().split("\n\n")
         for block in blocks:
             try:
-                question_match = re.search(r"Question:\s*(.*)", block)
-                correct_match = re.search(r"Correct Answer:\s*([a-d])", block)
+                lines = block.strip().splitlines()
+                if not lines:
+                    continue
+                # first line contains the question, potentially prefixed with
+                # "Question:" or a numbering scheme like "1." or "1)"
+                first_line = lines[0]
+                first_line = re.sub(r"^(?:Question[:\s]*|\d+[.)]\s*)", "", first_line).strip()
+                question = first_line
+                correct_match = re.search(r"Correct Answer:\s*([a-d])", block, re.I)
                 options = re.findall(r"[a-d]\)\s*(.*)", block)
 
-                if question_match and correct_match and options:
-                    idx = ord(correct_match.group(1).lower()) - ord('a')
-                    answer = options[idx]
-                    self.add_flashcard(Flashcard(question=question_match.group(1), answer=answer))
+                if question and correct_match and options:
+                    idx = ord(correct_match.group(1).lower()) - ord("a")
+                    answer = options[idx] if idx < len(options) else options[0]
+                    self.add_flashcard(Flashcard(question=question, answer=answer))
             except Exception as e:
                 print(f"⚠️ Error parsing block: {e}")
 

--- a/QuizModule/__init__.py
+++ b/QuizModule/__init__.py
@@ -8,11 +8,13 @@ and corresponding learning plans based on user performance.
 from .quiz_operations import (
     generate_quiz,
     generate_learning_plan_from_quiz,
+    generate_flashcards_from_quiz,
     prepare_quiz_questions,
 )
 
 __all__ = [
     "generate_quiz",
     "generate_learning_plan_from_quiz",
+    "generate_flashcards_from_quiz",
     "prepare_quiz_questions",
 ]

--- a/QuizModule/quiz_operations.py
+++ b/QuizModule/quiz_operations.py
@@ -7,6 +7,7 @@ from tools.quiz_prompts import generate_topic_list_prompt, generate_questions_pr
 from langchain_openai import ChatOpenAI
 from langchain.schema.runnable import RunnableLambda, RunnableParallel
 from LearningPlanModule.learning_plan import LearningPlan
+from FlashcardsModule import FlashcardSet
 from tools.language_handler import LanguageHandler
 from RAGModule.rag import RAGHandler
 from tools.auto_answer import auto_answer
@@ -147,3 +148,15 @@ def generate_learning_plan_from_quiz(user_name, quiz_results, language="en"):
     learning_plan = plan.generate_plan()
     plan.display_plan()
     return learning_plan
+
+
+def generate_flashcards_from_quiz(subject: str, questions: list[dict]) -> FlashcardSet:
+    """Create a FlashcardSet from quiz questions."""
+    flashcards = FlashcardSet(subject)
+    blocks = []
+    for q in questions:
+        block = q["question"].strip() + f"\nCorrect Answer: {q['correct']}"
+        blocks.append(block)
+    raw_text = "\n\n".join(blocks)
+    flashcards.generate_from_quiz_text(raw_text)
+    return flashcards

--- a/QuizModule/quiz_operations.py
+++ b/QuizModule/quiz_operations.py
@@ -150,13 +150,36 @@ def generate_learning_plan_from_quiz(user_name, quiz_results, language="en"):
     return learning_plan
 
 
-def generate_flashcards_from_quiz(subject: str, questions: list[dict]) -> FlashcardSet:
-    """Create a FlashcardSet from quiz questions."""
+def generate_flashcards_from_quiz(
+    subject: str,
+    questions: list[dict],
+    scores: dict | None = None,
+) -> FlashcardSet:
+    """Create a ``FlashcardSet`` from quiz questions.
+
+    If ``scores`` are provided, questions from lower scoring topics are
+    prioritized so the resulting flashcards focus on weaker areas.
+    """
     flashcards = FlashcardSet(subject)
+
+    if scores:
+        ordered_topics = sorted(
+            scores,
+            key=lambda t: (scores[t][0] / scores[t][1]) if scores[t][1] else 0,
+        )
+        ordered_questions = [
+            q for topic in ordered_topics for q in questions if q["topic"] == topic
+        ]
+    else:
+        ordered_questions = questions
+
     blocks = []
-    for q in questions:
-        block = q["question"].strip() + f"\nCorrect Answer: {q['correct']}"
+    for q in ordered_questions:
+        block = q["question"].strip()
+        if "Correct Answer" not in block:
+            block += f"\nCorrect Answer: {q['correct']}"
         blocks.append(block)
+
     raw_text = "\n\n".join(blocks)
     flashcards.generate_from_quiz_text(raw_text)
     return flashcards

--- a/frontend_service/interface.py
+++ b/frontend_service/interface.py
@@ -10,7 +10,12 @@ import gradio as gr
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from AgentModule import create_agent
-from QuizModule import generate_quiz, generate_learning_plan_from_quiz, prepare_quiz_questions
+from QuizModule import (
+    generate_quiz,
+    generate_learning_plan_from_quiz,
+    generate_flashcards_from_quiz,
+    prepare_quiz_questions,
+)
 from LearningPlanModule import LearningPlan
 from SummaryModule import StudySummaryGenerator
 from FlashcardsModule import FlashcardSet
@@ -160,6 +165,16 @@ def run_learning_plan_from_quiz(name: str, state: dict) -> str:
         generate_learning_plan_from_quiz(name, state["scores"], language)
     return buffer.getvalue()
 
+def run_flashcards_from_quiz(state: dict) -> tuple[list[dict], str]:
+    """Generate flashcards from the quiz questions."""
+    if not state or not state.get("questions"):
+        return [], "No quiz data available."
+    flashcards = generate_flashcards_from_quiz(state.get("subject", "Quiz"), state["questions"])
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        flashcards.save_to_file()
+    return flashcards.to_dict_list(), buffer.getvalue()
+
 def run_flashcards_generate(topic: str, use_rag: bool, lang_choice: str) -> tuple[list[dict], str]:
     """Generate flashcards from a topic."""
     code = LanguageHandler.code_from_display(lang_choice)
@@ -249,7 +264,10 @@ def build_interface() -> gr.Blocks:
                 quiz_result = gr.Markdown()
                 quiz_name = gr.Textbox(label="Your name")
                 plan_quiz_btn = gr.Button("Generate Learning Plan from Quiz")
+                fc_quiz_btn = gr.Button("Generate Flashcards from Quiz")
                 plan_quiz_output = gr.Textbox(label="Plan Output", lines=10)
+                fc_quiz_cards = gr.JSON(label="Flashcards")
+                fc_quiz_logs = gr.Textbox(label="Flashcard Logs", lines=4)
                 quiz_state = gr.State()
 
                 start_btn.click(start_quiz, [quiz_subject, quiz_rag, lang_select], [quiz_question, quiz_state, quiz_result])
@@ -258,6 +276,7 @@ def build_interface() -> gr.Blocks:
                 btn_c.click(lambda st: answer_quiz("c", st), quiz_state, [quiz_question, quiz_state, quiz_result])
                 btn_d.click(lambda st: answer_quiz("d", st), quiz_state, [quiz_question, quiz_state, quiz_result])
                 plan_quiz_btn.click(run_learning_plan_from_quiz, [quiz_name, quiz_state], plan_quiz_output)
+                fc_quiz_btn.click(run_flashcards_from_quiz, quiz_state, [fc_quiz_cards, fc_quiz_logs])
 
             # Learning plan tab
             with gr.TabItem("Learning plan"):

--- a/frontend_service/interface.py
+++ b/frontend_service/interface.py
@@ -166,10 +166,14 @@ def run_learning_plan_from_quiz(name: str, state: dict) -> str:
     return buffer.getvalue()
 
 def run_flashcards_from_quiz(state: dict) -> tuple[list[dict], str]:
-    """Generate flashcards from the quiz questions."""
+    """Generate flashcards from completed quiz questions."""
     if not state or not state.get("questions"):
         return [], "No quiz data available."
-    flashcards = generate_flashcards_from_quiz(state.get("subject", "Quiz"), state["questions"])
+    flashcards = generate_flashcards_from_quiz(
+        state.get("subject", "Quiz"),
+        state["questions"],
+        state.get("scores"),
+    )
     buffer = io.StringIO()
     with redirect_stdout(buffer):
         flashcards.save_to_file()


### PR DESCRIPTION
## Summary
- generate flashcards from completed quiz questions
- export the new helper
- add backend handler in Gradio to save flashcards from quiz
- expose button on quiz tab to create flashcards

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6887680c20a083238e4af37ea610f787