### PR TITLE
Add CSV ingestion

### DIFF
--- a/RAGModule/rag.py
+++ b/RAGModule/rag.py
@@ -2,7 +2,7 @@ import os
 from pathlib import Path
 from typing import List, Optional
 
-from langchain_community.document_loaders import TextLoader, PyPDFLoader
+from langchain_community.document_loaders import TextLoader, PyPDFLoader, CSVLoader
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain_openai import OpenAIEmbeddings
 try:  # Prefer standalone package but fall back for compatibility
@@ -85,6 +85,14 @@ class RAGHandler:
                 docs.extend(loader.load())
             except Exception as e:
                 print(f"❌ Error loading {pdf_path}: {e}")
+
+        # 📄 Load CSV files (search recursively)
+        for csv_path in self.rag_path.rglob("*.csv"):
+            try:
+                loader = CSVLoader(str(csv_path))
+                docs.extend(loader.load())
+            except Exception as e:
+                print(f"❌ Error loading {csv_path}: {e}")
 
         return docs
 


### PR DESCRIPTION
## Summary
- enhance `RAGHandler.ingest()` to load `*.csv` files via `CSVLoader`

## Testing
- `pytest -q`
- `python - <<'PY'
from RAGModule import RAGHandler
rag = RAGHandler()
try:
    rag.build_vectorstore()
    print('Docs count:', rag.vectordb._collection.count())
except Exception as e:
    print('Error:', e)
PY` *(fails: `openaipublic.blob.core.windows.net` blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688774012adc8323ad62deb0e94fe107