### PR TITLE
Center flashcard text

### DIFF
--- a/frontend_service/interface.py
+++ b/frontend_service/interface.py
@@ -62,6 +62,9 @@ CSS = """
   min-height: 120px;
   font-size: 1.1em;
   margin-bottom: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 #flashcard-buttons {
   display: grid;


### PR DESCRIPTION
## Summary
- center flashcard text vertically in the viewer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a06fdf4b8832398ca6942e625bcb4