### PR TITLE
Integrate reranking in RAG workflows

### DIFF
--- a/CheatSheetModule/cheatsheet_generator.py
+++ b/CheatSheetModule/cheatsheet_generator.py
@@ -63,11 +63,10 @@ Respond in this language only: {language}
             if retriever:
                 docs = retriever.get_relevant_documents(inputs["input"])
                 ctx = "\n\n".join([doc.page_content for doc in docs])
-
             else:
                 rag = RAGHandler()
                 rag.load_vectorstore()
-                ctx = rag.get_context(inputs["input"], k=3)
+                ctx = rag.get_context(inputs["input"], k=3, use_rerank=True)
             return {
                 "input": inputs["input"],
                 "language": inputs["language"],

--- a/FlashcardsModule/flashcards.py
+++ b/FlashcardsModule/flashcards.py
@@ -74,7 +74,7 @@ class FlashcardSet:
             else:
                 rag = RAGHandler()
                 rag.load_vectorstore()
-                ctx = rag.get_context(inputs["topic_prompt"], k=3)
+                ctx = rag.get_context(inputs["topic_prompt"], k=3, use_rerank=True)
             return {**inputs, "context": ctx}
 
         def _skip_context(inputs):

--- a/QuizModule/quiz_operations.py
+++ b/QuizModule/quiz_operations.py
@@ -23,7 +23,7 @@ def prepare_quiz_questions(subject: str, language: str = "en", use_rag: bool = F
         else:
             rag = RAGHandler()
             rag.load_vectorstore()
-            docs = rag.semantic_search(subject, k=3)
+            docs = rag.semantic_search(subject, k=3, use_rerank=True)
         context = "\n\n".join([doc.page_content for doc in docs])
 
     prompt_subject = subject
@@ -56,7 +56,9 @@ def prepare_quiz_questions(subject: str, language: str = "en", use_rag: bool = F
         else:
             rag = RAGHandler()
             rag.load_vectorstore()
-            context_chain = RunnableLambda(lambda inputs: rag.get_context(inputs["topic"], k=3))
+            context_chain = RunnableLambda(
+                lambda inputs: rag.get_context(inputs["topic"], k=3, use_rerank=True)
+            )
         prompt_chain = RunnableLambda(
             lambda inputs: generate_questions_prompt(inputs["topic"], language=language).format_prompt(topic=inputs["topic"])
         )

--- a/SummaryModule/summary_generator.py
+++ b/SummaryModule/summary_generator.py
@@ -74,7 +74,7 @@ Respond in {language}.
             else:
                 rag = RAGHandler()
                 rag.load_vectorstore()
-                ctx = rag.get_context(inputs["input"], k=3)
+                ctx = rag.get_context(inputs["input"], k=3, use_rerank=True)
             inputs["input"] = f"{ctx}\n\n### Topic:\n{inputs['input']}"
             return inputs
 

--- a/tools/edu_tools.py
+++ b/tools/edu_tools.py
@@ -66,7 +66,7 @@ def document_search(query: str) -> str:
     """Answer a question using documents indexed by the system."""
     rag = _get_rag()
     try:
-        return rag.answer(query)
+        return rag.answer(query, use_rerank=True)
     except Exception as e:  # pragma: no cover - LLM errors
         return f"Error using RAG: {e}"
 


### PR DESCRIPTION
## Summary
- use the new `CrossEncoder` reranker for document search
- update summary, cheat sheet, flashcard and quiz modules to rerank RAG context

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688b35b3b3b483239db731daa3a44d9b