### PR TITLE
Fix gradio warning for Chatbot type

### DIFF
--- a/frontend_service/interface.py
+++ b/frontend_service/interface.py
@@ -93,8 +93,8 @@ CSS = """
 
 
 def respond(
-    message: str, history: list[tuple[str, str]], lang_choice: str
-) -> tuple[list[tuple[str, str]], str]:
+    message: str, history: list[dict[str, str]], lang_choice: str
+) -> tuple[list[dict[str, str]], str]:
     """Return updated chat history and logs.
 
     The user's message is yielded immediately so it appears in the UI while the
@@ -102,7 +102,10 @@ def respond(
     """
 
     # show the user's message right away with a placeholder for the response
-    history = history + [(message, "...")]
+    history = history + [
+        {"role": "user", "content": message},
+        {"role": "assistant", "content": "..."},
+    ]
     yield history, ""
 
     code = LanguageHandler.code_from_display(lang_choice)
@@ -120,7 +123,7 @@ def respond(
             result = f"<div class='fallback'>{notice}<br>{result}</div>"
 
     # replace the placeholder with the actual response
-    history[-1] = (message, result)
+    history[-1] = {"role": "assistant", "content": result}
     logs = buffer.getvalue()
     yield history, logs
 
@@ -355,7 +358,7 @@ def build_interface() -> gr.Blocks:
         with gr.Tabs():
             # Chat tab
             with gr.TabItem("Chat with the bot"):
-                chatbot = gr.Chatbot(elem_id="chatbot")
+                chatbot = gr.Chatbot(elem_id="chatbot", type="messages")
                 with gr.Row():
                     msg = gr.Textbox(
                         placeholder="Type your message and press enter...",


### PR DESCRIPTION
## Summary
- update Chatbot instantiation to use `type="messages"`
- adapt `respond` generator to work with message dictionaries

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688cadee9b7483238a2414241d65ad5d