### PR TITLE
Refactor cheat sheet generator to simplify RAG usage

### DIFF
--- a/CheatSheetModule/cheatsheet_generator.py
+++ b/CheatSheetModule/cheatsheet_generator.py
@@ -1,7 +1,5 @@
 from langchain_openai import ChatOpenAI
 from langchain_core.prompts import PromptTemplate
-from langchain.schema.runnable import RunnableLambda, RunnableBranch, RunnableSequence
-from RAGModule.rag import RAGHandler
 
 # TODO: test and optimize
 
@@ -49,48 +47,27 @@ Respond only in {language}.
         self,
         input_text: str,
         language: str = "en",
-        use_rag: bool = False,
         retriever=None
     ) -> str:
         """
-        Generate a cheat sheet; uses RAG if use_rag=True.
+        Generate a cheat sheet with optional retrieved context.
 
         Args:
             input_text: topic or material for which to generate the cheat sheet
             language: language code for the output
-            use_rag: if True, fetch additional context from your documents
-            retriever: optional external retriever to supply that context
+            retriever: optional external retriever to supply context
 
         Returns:
             Generated cheat sheet as string.
         """
         retriever = retriever or self.retriever
 
-        def _fetch_context(inputs):
-            if retriever:
-                docs = retriever.get_relevant_documents(inputs["input"])
-                ctx = "\n\n".join([doc.page_content for doc in docs])
+        ctx = ""
+        if retriever:
+            docs = retriever.get_relevant_documents(input_text)
+            ctx = "\n\n".join(d.page_content for d in docs)
 
-            else:
-                rag = RAGHandler()
-                rag.load_vectorstore()
-                ctx = rag.get_context(inputs["input"], k=3)
-            return {
-                "input": inputs["input"],
-                "language": inputs["language"],
-                "context": ctx,
-            }
-
-
-        def _skip_context(inputs):
-            return {"input": inputs["input"], "language": inputs["language"], "context": ""}
-
-        branch = RunnableBranch(
-            (lambda d: d.get("use_rag", False), RunnableLambda(_fetch_context)),
-            RunnableLambda(_skip_context)
+        response = (self.prompt | self.llm).invoke(
+            {"input": input_text, "language": language, "context": ctx}
         )
-
-        chain = RunnableSequence(branch, self.prompt | self.llm)
-
-        response = chain.invoke({"input": input_text, "language": language, "use_rag": use_rag})
         return response.content

--- a/frontend_service/interface.py
+++ b/frontend_service/interface.py
@@ -334,12 +334,12 @@ def run_summary_interface(topic: str, use_rag: bool, lang_choice: str) -> str:
     return summarizer.generate_summary(topic, language=language, use_rag=use_rag)
 
 
-def run_cheatsheet_interface(topic: str, use_rag: bool, lang_choice: str) -> str:
+def run_cheatsheet_interface(topic: str, lang_choice: str) -> str:
     """Generate a cheat sheet."""
     code = LanguageHandler.code_from_display(lang_choice)
     language = code if code != "auto" else LanguageHandler.choose_or_detect(topic)
     generator = CheatSheetGenerator()
-    return generator.generate_cheatsheet(topic, language=language, use_rag=use_rag)
+    return generator.generate_cheatsheet(topic, language=language)
 
 
 def build_interface() -> gr.Blocks:
@@ -503,11 +503,10 @@ def build_interface() -> gr.Blocks:
             # Cheat sheet tab
             with gr.TabItem("Cheat sheet"):
                 cs_topic = gr.Textbox(label="Topic or material")
-                cs_rag = gr.Checkbox(label="Use RAG", value=False)
                 cs_btn = gr.Button("Generate Cheat Sheet")
                 cs_output = gr.Textbox(label="Cheat Sheet", lines=10)
                 cs_btn.click(
-                    run_cheatsheet_interface, [cs_topic, cs_rag, lang_select], cs_output
+                    run_cheatsheet_interface, [cs_topic, lang_select], cs_output
                 )
 
     return demo

--- a/main.py
+++ b/main.py
@@ -219,17 +219,14 @@ def main_menu():
         elif choice == "7":
             topic = prompt_input("Enter the topic or material for the cheat sheet: ")
             language = LanguageHandler.choose_or_detect(topic)
-            # pass retriever to cheat sheet generator
-            generator = CheatSheetGenerator(retriever=retriever)
             use_rag = (
                 prompt_input("Enrich cheat sheet with your documents? (y/N): ")
                 .strip()
                 .lower()
                 == "y"
             )
-            cheatsheet = generator.generate_cheatsheet(
-                topic, language=language, use_rag=use_rag, retriever=retriever
-            )
+            generator = CheatSheetGenerator(retriever=retriever if use_rag else None)
+            cheatsheet = generator.generate_cheatsheet(topic, language=language)
             print("\n📄 Cheat Sheet:\n")
             print(cheatsheet)
 


### PR DESCRIPTION
## Summary
- Simplify `CheatSheetGenerator` by removing `use_rag` flag and RAGHandler dependency.
- Update CLI and Gradio interface to use the new generator signature and drop RAG checkbox.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891e00d8c908323a22d4eabd5f1335d