### PR TITLE
Simplify summary generator context retrieval

### DIFF
--- a/SummaryModule/summary_generator.py
+++ b/SummaryModule/summary_generator.py
@@ -1,17 +1,17 @@
 from langchain_openai import ChatOpenAI
 from langchain_core.prompts import PromptTemplate
 from tools.language_handler import LanguageHandler
-from langchain.schema.runnable import RunnableLambda, RunnableBranch, RunnableSequence
-from RAGModule.rag import RAGHandler
 
-# TODO: optimize with pipeline, quering, give more detailed contents, maybe more examples :  with ML prompt there are no examples of algorithms ect. 
+# TODO: optimize with pipeline, quering, give more detailed contents, maybe more examples :  with ML prompt there are no examples of algorithms ect.
+
 
 class StudySummaryGenerator:
     """
     Generates a detailed study guide based on a topic – intended for learning, not just review.
     Ideal for exam preparation.
     """
-    def __init__(self, model_name="gpt-3.5-turbo", temperature=0.5,retriever=None):
+
+    def __init__(self, model_name="gpt-3.5-turbo", temperature=0.5, retriever=None):
         self.llm = ChatOpenAI(model=model_name, temperature=temperature)
         self.retriever = retriever
 
@@ -48,45 +48,28 @@ Only output the content. No introductions or commentary.
 
 Respond in {language}.
 """
-        ) 
-
-    def generate_summary(
-        self,
-        input_text: str,
-        language: str = "en",
-        use_rag: bool = False,
-        retriever=None
-    ) -> str:
-        """
-        Generate a detailed study summary using the configured LLM and prompt.
-        If ``use_rag`` is True, an external ``retriever`` can be supplied for
-        context; otherwise a new :class:`RAGHandler` will be used.
-        """
-        lang = LanguageHandler.choose_or_detect(input_text) if language == "auto" else language
-
-        retriever = retriever or self.retriever
-
-        def _fetch_context(inputs):
-            if retriever:
-                """Retrieve additional context using RAG if a retriever is provided."""
-                docs = retriever.get_relevant_documents(inputs["input"])
-                ctx = "\n\n".join([doc.page_content for doc in docs])
-            else:
-                rag = RAGHandler()
-                rag.load_vectorstore()
-                ctx = rag.get_context(inputs["input"], k=3)
-            inputs["input"] = f"{ctx}\n\n### Topic:\n{inputs['input']}"
-            return inputs
-
-        def _skip_context(inputs):
-            return inputs
-
-        branch = RunnableBranch(
-            (lambda d: d.get("use_rag", False), RunnableLambda(_fetch_context)),
-            RunnableLambda(_skip_context)
         )
 
-        chain = RunnableSequence(branch, self.base_prompt | self.llm)
+    def generate_summary(
+        self, input_text: str, language: str = "en", retriever=None
+    ) -> str:
+        """Generate a detailed study summary using the configured LLM and prompt.
 
-        response = chain.invoke({"input": input_text, "language": lang, "use_rag": use_rag})
+        If a ``retriever`` is provided, it will be used to supply additional
+        context for the summary.
+        """
+        lang = (
+            LanguageHandler.choose_or_detect(input_text)
+            if language == "auto"
+            else language
+        )
+
+        retriever = retriever or self.retriever
+        if retriever:
+            docs = retriever.get_relevant_documents(input_text)
+            ctx = "\n\n".join([doc.page_content for doc in docs])
+            input_text = f"{ctx}\n\n### Topic:\n{input_text}"
+
+        chain = self.base_prompt | self.llm
+        response = chain.invoke({"input": input_text, "language": lang})
         return response.content

--- a/frontend_service/interface.py
+++ b/frontend_service/interface.py
@@ -17,6 +17,7 @@ from FlashcardsModule import FlashcardSet
 from LearningPlanModule import LearningPlan
 from QuizModule import generate_learning_plan_from_quiz, prepare_quiz_questions
 from SummaryModule import StudySummaryGenerator
+from RAGModule import RAGHandler
 from tools.language_handler import LanguageHandler
 
 dotenv_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".env"))
@@ -331,7 +332,8 @@ def run_summary_interface(topic: str, use_rag: bool, lang_choice: str) -> str:
     code = LanguageHandler.code_from_display(lang_choice)
     language = code if code != "auto" else LanguageHandler.choose_or_detect(topic)
     summarizer = StudySummaryGenerator()
-    return summarizer.generate_summary(topic, language=language, use_rag=use_rag)
+    retriever = RAGHandler().get_retriever(k=5) if use_rag else None
+    return summarizer.generate_summary(topic, language=language, retriever=retriever)
 
 
 def run_cheatsheet_interface(topic: str, use_rag: bool, lang_choice: str) -> str:

--- a/main.py
+++ b/main.py
@@ -203,15 +203,17 @@ def main_menu():
             topic = prompt_input("Enter the topic or material for TL;DR summary: ")
             language = LanguageHandler.choose_or_detect(topic)
             # pass retriever to summary
-            summarizer = StudySummaryGenerator(retriever=retriever)
             use_rag = (
                 prompt_input("Enrich summary with your documents? (y/N): ")
                 .strip()
                 .lower()
                 == "y"
             )
+            summarizer = StudySummaryGenerator()
             summary = summarizer.generate_summary(
-                topic, language=language, use_rag=use_rag, retriever=retriever
+                topic,
+                language=language,
+                retriever=retriever if use_rag else None,
             )
             print("\n📘 Summary:\n")
             print(summary)


### PR DESCRIPTION
## Summary
- Refactor `StudySummaryGenerator.generate_summary` to accept an optional `retriever` and drop `use_rag` flag.
- Remove RAG-specific imports and runnable branching logic in favor of a direct `if retriever` block.
- Update CLI and frontend to use the new signature, instantiating a retriever only when needed.

## Testing
- `python -m black SummaryModule/summary_generator.py main.py frontend_service/interface.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891e00e2780832380cf412c72de5be4