### PR TITLE
Remove RAG integration from CLI

### DIFF
--- a/CheatSheetModule/cheatsheet_generator.py
+++ b/CheatSheetModule/cheatsheet_generator.py
@@ -1,7 +1,6 @@
 from langchain_openai import ChatOpenAI
 from langchain_core.prompts import PromptTemplate
 from langchain.schema.runnable import RunnableLambda, RunnableBranch, RunnableSequence
-from RAGModule.rag import RAGHandler
 
 # TODO: test and optimize
 
@@ -46,20 +45,16 @@ Respond only in {language}.
         )
 
     def generate_cheatsheet(
-        self,
-        input_text: str,
-        language: str = "en",
-        use_rag: bool = False,
-        retriever=None
+        self, input_text: str, language: str = "en", retriever=None
     ) -> str:
         """
-        Generate a cheat sheet; uses RAG if use_rag=True.
+        Generate a cheat sheet. If a ``retriever`` is provided, additional
+        context from your documents is fetched and prepended to the prompt.
 
         Args:
             input_text: topic or material for which to generate the cheat sheet
             language: language code for the output
-            use_rag: if True, fetch additional context from your documents
-            retriever: optional external retriever to supply that context
+            retriever: optional external retriever to supply context
 
         Returns:
             Generated cheat sheet as string.
@@ -67,30 +62,23 @@ Respond only in {language}.
         retriever = retriever or self.retriever
 
         def _fetch_context(inputs):
-            if retriever:
-                docs = retriever.get_relevant_documents(inputs["input"])
-                ctx = "\n\n".join([doc.page_content for doc in docs])
-
-            else:
-                rag = RAGHandler()
-                rag.load_vectorstore()
-                ctx = rag.get_context(inputs["input"], k=3)
+            docs = retriever.get_relevant_documents(inputs["input"])
+            ctx = "\n\n".join([doc.page_content for doc in docs])
             return {
                 "input": inputs["input"],
                 "language": inputs["language"],
                 "context": ctx,
             }
 
-
         def _skip_context(inputs):
             return {"input": inputs["input"], "language": inputs["language"], "context": ""}
 
         branch = RunnableBranch(
-            (lambda d: d.get("use_rag", False), RunnableLambda(_fetch_context)),
-            RunnableLambda(_skip_context)
+            (lambda _: retriever is not None, RunnableLambda(_fetch_context)),
+            RunnableLambda(_skip_context),
         )
 
         chain = RunnableSequence(branch, self.prompt | self.llm)
 
-        response = chain.invoke({"input": input_text, "language": language, "use_rag": use_rag})
+        response = chain.invoke({"input": input_text, "language": language})
         return response.content

--- a/FlashcardsModule/flashcards.py
+++ b/FlashcardsModule/flashcards.py
@@ -6,8 +6,6 @@ from datetime import datetime
 from langchain.chains import RetrievalQA
 from langchain.schema.runnable import RunnableBranch, RunnableLambda, RunnableSequence
 from langchain_openai import ChatOpenAI
-
-from RAGModule.rag import RAGHandler
 from tools.auto_answer import auto_answer
 
 
@@ -62,36 +60,25 @@ class FlashcardSet:
                 print(f"⚠️ Error parsing block: {e}")
 
     def generate_from_prompt(
-        self,
-        topic_prompt: str,
-        language: str = "en",
-        use_rag: bool = False,
-        retriever=None,
+        self, topic_prompt: str, language: str = "en", retriever=None
     ):
         """
-        Uses an LLM (optionally with RAG) to generate flashcards based on a topic prompt.
-        When ``use_rag`` is True, additional context from your indexed documents is
-        fetched and prepended to the prompt. If a ``retriever`` was supplied and
-        ``use_rag`` is ``True``, it is used via ``RetrievalQA`` for generation.
+        Generate flashcards for the given topic prompt. If a ``retriever`` is
+        provided, it is used to prepend relevant context to the prompt.
         """
         llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=0.5, verbose=True)
         retriever = retriever or self.retriever
 
         def _fetch_context(inputs):
-            if retriever:
-                docs = retriever.get_relevant_documents(inputs["topic_prompt"])
-                ctx = "\n\n".join([doc.page_content for doc in docs])
-            else:
-                rag = RAGHandler()
-                rag.load_vectorstore()
-                ctx = rag.get_context(inputs["topic_prompt"], k=3)
+            docs = retriever.get_relevant_documents(inputs["topic_prompt"])
+            ctx = "\n\n".join([doc.page_content for doc in docs])
             return {**inputs, "context": ctx}
 
         def _skip_context(inputs):
             return {**inputs, "context": ""}
 
         branch = RunnableBranch(
-            (lambda d: d.get("use_rag", False), RunnableLambda(_fetch_context)),
+            (lambda _: retriever is not None, RunnableLambda(_fetch_context)),
             RunnableLambda(_skip_context),
         )
 
@@ -120,19 +107,14 @@ class FlashcardSet:
         chain = RunnableSequence(branch, RunnableLambda(_build_prompt) | llm)
 
         try:
-            # Use any available retriever only when RAG is enabled
-            if use_rag and retriever:
+            if retriever:
                 qa = RetrievalQA.from_chain_type(
                     llm=llm, chain_type="stuff", retriever=retriever
                 )
                 raw_output = qa.run(topic_prompt)
             else:
                 response = chain.invoke(
-                    {
-                        "topic_prompt": topic_prompt,
-                        "language": language,
-                        "use_rag": use_rag,
-                    }
+                    {"topic_prompt": topic_prompt, "language": language}
                 )
                 raw_output = response.content
 

--- a/QuizModule/quiz_operations.py
+++ b/QuizModule/quiz_operations.py
@@ -8,22 +8,16 @@ from langchain_openai import ChatOpenAI
 from langchain.schema.runnable import RunnableLambda, RunnableParallel
 from LearningPlanModule.learning_plan import LearningPlan
 from tools.language_handler import LanguageHandler
-from RAGModule.rag import RAGHandler
 from tools.auto_answer import auto_answer
 
 
-def prepare_quiz_questions(subject: str, language: str = "en", use_rag: bool = False, retriever=None) -> list[dict]:
+def prepare_quiz_questions(subject: str, language: str = "en", retriever=None) -> list[dict]:
     """Return a list of quiz questions without running an interactive loop."""
     llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=0.1, verbose=True)
 
     context = ""
-    if use_rag:
-        if retriever:
-            docs = retriever.get_relevant_documents(subject)
-        else:
-            rag = RAGHandler()
-            rag.load_vectorstore()
-            docs = rag.semantic_search(subject, k=3)
+    if retriever:
+        docs = retriever.get_relevant_documents(subject)
         context = "\n\n".join([doc.page_content for doc in docs])
 
     prompt_subject = subject
@@ -46,19 +40,19 @@ def prepare_quiz_questions(subject: str, language: str = "en", use_rag: bool = F
     questions_per_topic = max_questions // max_topics
 
     # Generate questions in parallel
-    if use_rag:
-        if retriever:
-            context_chain = RunnableLambda(
-                lambda inputs: "\n\n".join(
-                    [doc.page_content for doc in retriever.get_relevant_documents(inputs["topic"])]
-                )
+    if retriever:
+        context_chain = RunnableLambda(
+            lambda inputs: "\n\n".join(
+                [
+                    doc.page_content
+                    for doc in retriever.get_relevant_documents(inputs["topic"])
+                ]
             )
-        else:
-            rag = RAGHandler()
-            rag.load_vectorstore()
-            context_chain = RunnableLambda(lambda inputs: rag.get_context(inputs["topic"], k=3))
+        )
         prompt_chain = RunnableLambda(
-            lambda inputs: generate_questions_prompt(inputs["topic"], language=language).format_prompt(topic=inputs["topic"])
+            lambda inputs: generate_questions_prompt(
+                inputs["topic"], language=language
+            ).format_prompt(topic=inputs["topic"])
         )
         question_chain = (
             RunnableParallel({"ctx": context_chain, "prompt": prompt_chain})
@@ -67,7 +61,9 @@ def prepare_quiz_questions(subject: str, language: str = "en", use_rag: bool = F
         )
     else:
         question_chain = RunnableLambda(
-            lambda inputs: generate_questions_prompt(inputs["topic"], language=language).format_prompt(topic=inputs["topic"])
+            lambda inputs: generate_questions_prompt(
+                inputs["topic"], language=language
+            ).format_prompt(topic=inputs["topic"])
         ) | llm
 
     question_sets = question_chain.batch([{"topic": t} for t in topics])
@@ -83,10 +79,12 @@ def prepare_quiz_questions(subject: str, language: str = "en", use_rag: bool = F
 
     return questions_list
 
-def generate_quiz(subject: str, language: str = "en", use_rag: bool = False, retriever=None):
+def generate_quiz(subject: str, language: str = "en", retriever=None):
     """Run an interactive quiz in the terminal and return the results."""
     try:
-        questions = prepare_quiz_questions(subject, language=language, use_rag=use_rag, retriever=retriever)
+        questions = prepare_quiz_questions(
+            subject, language=language, retriever=retriever
+        )
         if not questions:
             print("\u26a0\ufe0f No quiz topics generated.")
             return {}

--- a/SummaryModule/summary_generator.py
+++ b/SummaryModule/summary_generator.py
@@ -2,7 +2,6 @@ from langchain_openai import ChatOpenAI
 from langchain_core.prompts import PromptTemplate
 from tools.language_handler import LanguageHandler
 from langchain.schema.runnable import RunnableLambda, RunnableBranch, RunnableSequence
-from RAGModule.rag import RAGHandler
 
 # TODO: optimize with pipeline, quering, give more detailed contents, maybe more examples :  with ML prompt there are no examples of algorithms ect. 
 
@@ -51,30 +50,24 @@ Respond in {language}.
         ) 
 
     def generate_summary(
-        self,
-        input_text: str,
-        language: str = "en",
-        use_rag: bool = False,
-        retriever=None
+        self, input_text: str, language: str = "en", retriever=None
     ) -> str:
         """
         Generate a detailed study summary using the configured LLM and prompt.
-        If ``use_rag`` is True, an external ``retriever`` can be supplied for
-        context; otherwise a new :class:`RAGHandler` will be used.
+        If a ``retriever`` is provided, additional context is fetched and
+        prepended to the prompt.
         """
-        lang = LanguageHandler.choose_or_detect(input_text) if language == "auto" else language
+        lang = (
+            LanguageHandler.choose_or_detect(input_text)
+            if language == "auto"
+            else language
+        )
 
         retriever = retriever or self.retriever
 
         def _fetch_context(inputs):
-            if retriever:
-                """Retrieve additional context using RAG if a retriever is provided."""
-                docs = retriever.get_relevant_documents(inputs["input"])
-                ctx = "\n\n".join([doc.page_content for doc in docs])
-            else:
-                rag = RAGHandler()
-                rag.load_vectorstore()
-                ctx = rag.get_context(inputs["input"], k=3)
+            docs = retriever.get_relevant_documents(inputs["input"])
+            ctx = "\n\n".join([doc.page_content for doc in docs])
             inputs["input"] = f"{ctx}\n\n### Topic:\n{inputs['input']}"
             return inputs
 
@@ -82,11 +75,11 @@ Respond in {language}.
             return inputs
 
         branch = RunnableBranch(
-            (lambda d: d.get("use_rag", False), RunnableLambda(_fetch_context)),
-            RunnableLambda(_skip_context)
+            (lambda _: retriever is not None, RunnableLambda(_fetch_context)),
+            RunnableLambda(_skip_context),
         )
 
         chain = RunnableSequence(branch, self.base_prompt | self.llm)
 
-        response = chain.invoke({"input": input_text, "language": lang, "use_rag": use_rag})
+        response = chain.invoke({"input": input_text, "language": lang})
         return response.content

--- a/frontend_service/interface.py
+++ b/frontend_service/interface.py
@@ -136,11 +136,11 @@ def _format_question(q: dict) -> str:
     return f"**{q['topic']}**\n\n{text}"
 
 
-def start_quiz(subject: str, use_rag: bool, lang_choice: str) -> tuple[str, dict, str]:
+def start_quiz(subject: str, lang_choice: str) -> tuple[str, dict, str]:
     """Generate quiz questions and return the first one with state."""
     code = LanguageHandler.code_from_display(lang_choice)
     language = code if code != "auto" else LanguageHandler.choose_or_detect(subject)
-    questions = prepare_quiz_questions(subject, language=language, use_rag=use_rag)
+    questions = prepare_quiz_questions(subject, language=language)
     if not questions:
         return "Failed to generate quiz.", {}, ""
     state = {
@@ -247,18 +247,14 @@ def _render_flashcard(state: dict) -> str:
     return card.get(side, "")
 
 
-def run_flashcards_generate(
-    topic: str, use_rag: bool, lang_choice: str
-) -> tuple[str, dict, str, str]:
+def run_flashcards_generate(topic: str, lang_choice: str) -> tuple[str, dict, str, str]:
     """Generate flashcards from a topic and prepare viewer state."""
     code = LanguageHandler.code_from_display(lang_choice)
     language = code if code != "auto" else LanguageHandler.choose_or_detect(topic)
     flashcards = FlashcardSet(topic)
     buffer = io.StringIO()
     with redirect_stdout(buffer):
-        flashcards.generate_from_prompt(
-            topic_prompt=topic, language=language, use_rag=use_rag
-        )
+        flashcards.generate_from_prompt(topic_prompt=topic, language=language)
         path = flashcards.save_to_file()
     logs = buffer.getvalue()
     if path:
@@ -326,20 +322,20 @@ def flashcard_shuffle(state: dict) -> tuple[str, dict, str]:
     return _render_flashcard(state), state, f"1/{len(state['cards'])}"
 
 
-def run_summary_interface(topic: str, use_rag: bool, lang_choice: str) -> str:
+def run_summary_interface(topic: str, lang_choice: str) -> str:
     """Generate a detailed study summary."""
     code = LanguageHandler.code_from_display(lang_choice)
     language = code if code != "auto" else LanguageHandler.choose_or_detect(topic)
     summarizer = StudySummaryGenerator()
-    return summarizer.generate_summary(topic, language=language, use_rag=use_rag)
+    return summarizer.generate_summary(topic, language=language)
 
 
-def run_cheatsheet_interface(topic: str, use_rag: bool, lang_choice: str) -> str:
+def run_cheatsheet_interface(topic: str, lang_choice: str) -> str:
     """Generate a cheat sheet."""
     code = LanguageHandler.code_from_display(lang_choice)
     language = code if code != "auto" else LanguageHandler.choose_or_detect(topic)
     generator = CheatSheetGenerator()
-    return generator.generate_cheatsheet(topic, language=language, use_rag=use_rag)
+    return generator.generate_cheatsheet(topic, language=language)
 
 
 def build_interface() -> gr.Blocks:
@@ -375,7 +371,6 @@ def build_interface() -> gr.Blocks:
             # Quiz tab
             with gr.TabItem("Generate quiz"):
                 quiz_subject = gr.Textbox(label="Subject")
-                quiz_rag = gr.Checkbox(label="Use RAG", value=False)
                 start_btn = gr.Button("Start Quiz")
                 quiz_question = gr.Markdown()
                 with gr.Row():
@@ -391,7 +386,7 @@ def build_interface() -> gr.Blocks:
 
                 start_btn.click(
                     start_quiz,
-                    [quiz_subject, quiz_rag, lang_select],
+                    [quiz_subject, lang_select],
                     [quiz_question, quiz_state, quiz_result],
                 )
                 btn_a.click(
@@ -436,7 +431,6 @@ def build_interface() -> gr.Blocks:
             with gr.TabItem("Flashcards"):
                 with gr.Accordion("Generate flashcards", open=True):
                     fc_topic = gr.Textbox(label="Topic")
-                    fc_rag = gr.Checkbox(label="Use RAG", value=False)
                     fc_gen_btn = gr.Button("Generate")
                     with gr.Column(elem_id="flashcard-container"):
                         fc_card = gr.Markdown(elem_id="flashcard-content")
@@ -451,7 +445,7 @@ def build_interface() -> gr.Blocks:
 
                     fc_gen_btn.click(
                         run_flashcards_generate,
-                        [fc_topic, fc_rag, lang_select],
+                        [fc_topic, lang_select],
                         [fc_card, fc_state, fc_logs, fc_counter],
                         show_progress=False,
                     )
@@ -493,21 +487,19 @@ def build_interface() -> gr.Blocks:
             # Summary tab
             with gr.TabItem("Summary"):
                 sum_topic = gr.Textbox(label="Topic or material")
-                sum_rag = gr.Checkbox(label="Use RAG", value=False)
                 sum_btn = gr.Button("Generate Summary")
                 sum_output = gr.Textbox(label="Summary", lines=10)
                 sum_btn.click(
-                    run_summary_interface, [sum_topic, sum_rag, lang_select], sum_output
+                    run_summary_interface, [sum_topic, lang_select], sum_output
                 )
 
             # Cheat sheet tab
             with gr.TabItem("Cheat sheet"):
                 cs_topic = gr.Textbox(label="Topic or material")
-                cs_rag = gr.Checkbox(label="Use RAG", value=False)
                 cs_btn = gr.Button("Generate Cheat Sheet")
                 cs_output = gr.Textbox(label="Cheat Sheet", lines=10)
                 cs_btn.click(
-                    run_cheatsheet_interface, [cs_topic, cs_rag, lang_select], cs_output
+                    run_cheatsheet_interface, [cs_topic, lang_select], cs_output
                 )
 
     return demo

--- a/main.py
+++ b/main.py
@@ -9,7 +9,6 @@ from AgentModule.edu_agent import run_agent
 from frontend_service import launch_gradio
 from tools.auto_answer import auto_answer
 from tools.language_handler import LanguageHandler
-from RAGModule import RAGHandler
 import os
 import warnings
 from langchain_core._api import LangChainDeprecationWarning
@@ -38,33 +37,16 @@ def prompt_input(prompt: str) -> str:
 
 
 def chat_with_bot():
-    """Chat with the assistant. Optionally use RAG for document context."""
+    """Chat with the assistant."""
     try:
-        use_rag = (
-            prompt_input("Enrich answers with your documents? (y/N): ").strip().lower()
-            == "y"
-        )
-
         chat_history = []
-
-        if use_rag:
-            rag = RAGHandler()
-            rag.load_vectorstore()
-            print(
-                "RAG mode enabled. You can now chat with the bot. Type 'exit' or 'q' to quit."
-            )
-        else:
-            rag = None
-            print("You can now chat with the bot. Type 'exit' or 'q' to quit.")
+        print("You can now chat with the bot. Type 'exit' or 'q' to quit.")
 
         while True:
             query = prompt_input("You: ")
             if query.lower() in ["exit", "q"]:
                 break
 
-            if use_rag and rag:
-                # Pre-load vector store so the agent can query documents
-                pass
             language = LanguageHandler.choose_or_detect(query)
             answer, used_fallback = run_agent(
                 query, executor=_agent, return_details=True
@@ -92,13 +74,8 @@ def main_menu():
     """
     Main menu for the application.
     """
-    # Initialize RAG handler and retriever (optional)
-    try:
-        rag = RAGHandler()
-        retriever = rag.get_retriever(k=5)
-    except Exception as e:
-        print(f"[RAG Init Error] {e}")
-        retriever = None
+    # TODO: Re-integrate RAG retriever initialization here in the future
+    retriever = None
 
     while True:
         print("\nSelect an option:")
@@ -128,14 +105,7 @@ def main_menu():
         elif choice == "2":
             subject = prompt_input("Enter the subject for the quiz: ")
             language = LanguageHandler.choose_or_detect(subject)
-            # pass retriever to quiz (RAG-enabled if available)
-            use_rag = (
-                prompt_input("Use RAG to generate quiz topics? (y/N): ").strip().lower()
-                == "y"
-            )
-            generate_quiz(
-                subject, language=language, use_rag=use_rag, retriever=retriever
-            )
+            generate_quiz(subject, language=language, retriever=retriever)
 
         elif choice == "3":
             print("\nSelect an option:")
@@ -146,14 +116,8 @@ def main_menu():
             if sub_choice == "1":
                 subject = prompt_input("Enter the subject for the quiz: ")
                 language = LanguageHandler.choose_or_detect(subject)
-                use_rag = (
-                    prompt_input("Use RAG to generate quiz topics? (y/N): ")
-                    .strip()
-                    .lower()
-                    == "y"
-                )
                 quiz_results = generate_quiz(
-                    subject, language=language, use_rag=use_rag, retriever=retriever
+                    subject, language=language, retriever=retriever
                 )
                 user_name = prompt_input("Enter your name: ")
                 generate_learning_plan_from_quiz(user_name, quiz_results, language)
@@ -176,19 +140,9 @@ def main_menu():
         elif choice == "4":
             topic = prompt_input("Enter a topic for flashcard generation: ")
             language = LanguageHandler.choose_or_detect(topic)
-            # pass retriever to flashcards
             flashcards = FlashcardSet(topic, retriever=retriever)
-            use_rag = (
-                prompt_input("Enrich flashcards with your documents? (y/N): ")
-                .strip()
-                .lower()
-                == "y"
-            )
             flashcards.generate_from_prompt(
-                topic_prompt=topic,
-                language=language,
-                use_rag=use_rag,
-                retriever=retriever,
+                topic_prompt=topic, language=language, retriever=retriever
             )
             print(flashcards.to_dict_list())
             flashcards.save_to_file()
@@ -202,16 +156,9 @@ def main_menu():
         elif choice == "6":
             topic = prompt_input("Enter the topic or material for TL;DR summary: ")
             language = LanguageHandler.choose_or_detect(topic)
-            # pass retriever to summary
             summarizer = StudySummaryGenerator(retriever=retriever)
-            use_rag = (
-                prompt_input("Enrich summary with your documents? (y/N): ")
-                .strip()
-                .lower()
-                == "y"
-            )
             summary = summarizer.generate_summary(
-                topic, language=language, use_rag=use_rag, retriever=retriever
+                topic, language=language, retriever=retriever
             )
             print("\n📘 Summary:\n")
             print(summary)
@@ -219,16 +166,9 @@ def main_menu():
         elif choice == "7":
             topic = prompt_input("Enter the topic or material for the cheat sheet: ")
             language = LanguageHandler.choose_or_detect(topic)
-            # pass retriever to cheat sheet generator
             generator = CheatSheetGenerator(retriever=retriever)
-            use_rag = (
-                prompt_input("Enrich cheat sheet with your documents? (y/N): ")
-                .strip()
-                .lower()
-                == "y"
-            )
             cheatsheet = generator.generate_cheatsheet(
-                topic, language=language, use_rag=use_rag, retriever=retriever
+                topic, language=language, retriever=retriever
             )
             print("\n📄 Cheat Sheet:\n")
             print(cheatsheet)


### PR DESCRIPTION
## Summary
- simplify chat workflow by dropping runtime RAG option
- remove RAG prompts and flags from main menu modules
- note potential future retriever reintroduction

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6891e00f95c483239ef89cf5680ab812