### PR TITLE
Remove use_rag flags and rely on retriever

### DIFF
--- a/CheatSheetModule/cheatsheet_generator.py
+++ b/CheatSheetModule/cheatsheet_generator.py
@@ -1,7 +1,5 @@
 from langchain_openai import ChatOpenAI
 from langchain_core.prompts import PromptTemplate
-from langchain.schema.runnable import RunnableLambda, RunnableBranch, RunnableSequence
-from RAGModule.rag import RAGHandler
 
 # TODO: test and optimize
 
@@ -46,51 +44,27 @@ Respond only in {language}.
         )
 
     def generate_cheatsheet(
-        self,
-        input_text: str,
-        language: str = "en",
-        use_rag: bool = False,
-        retriever=None
+        self, input_text: str, language: str = "en", retriever=None
     ) -> str:
-        """
-        Generate a cheat sheet; uses RAG if use_rag=True.
+        """Generate a cheat sheet.
+
+        Additional context is fetched only when a ``retriever`` is provided.
 
         Args:
             input_text: topic or material for which to generate the cheat sheet
             language: language code for the output
-            use_rag: if True, fetch additional context from your documents
-            retriever: optional external retriever to supply that context
+            retriever: optional external retriever to supply context
 
         Returns:
             Generated cheat sheet as string.
         """
         retriever = retriever or self.retriever
 
-        def _fetch_context(inputs):
-            if retriever:
-                docs = retriever.get_relevant_documents(inputs["input"])
-                ctx = "\n\n".join([doc.page_content for doc in docs])
+        context = ""
+        if retriever:
+            docs = retriever.get_relevant_documents(input_text)
+            context = "\n\n".join([doc.page_content for doc in docs])
 
-            else:
-                rag = RAGHandler()
-                rag.load_vectorstore()
-                ctx = rag.get_context(inputs["input"], k=3)
-            return {
-                "input": inputs["input"],
-                "language": inputs["language"],
-                "context": ctx,
-            }
-
-
-        def _skip_context(inputs):
-            return {"input": inputs["input"], "language": inputs["language"], "context": ""}
-
-        branch = RunnableBranch(
-            (lambda d: d.get("use_rag", False), RunnableLambda(_fetch_context)),
-            RunnableLambda(_skip_context)
-        )
-
-        chain = RunnableSequence(branch, self.prompt | self.llm)
-
-        response = chain.invoke({"input": input_text, "language": language, "use_rag": use_rag})
+        inputs = {"input": input_text, "language": language, "context": context}
+        response = (self.prompt | self.llm).invoke(inputs)
         return response.content

--- a/FlashcardsModule/flashcards.py
+++ b/FlashcardsModule/flashcards.py
@@ -4,10 +4,7 @@ import re
 from datetime import datetime
 
 from langchain.chains import RetrievalQA
-from langchain.schema.runnable import RunnableBranch, RunnableLambda, RunnableSequence
 from langchain_openai import ChatOpenAI
-
-from RAGModule.rag import RAGHandler
 from tools.auto_answer import auto_answer
 
 
@@ -60,80 +57,47 @@ class FlashcardSet:
                     )
             except Exception as e:
                 print(f"⚠️ Error parsing block: {e}")
-
     def generate_from_prompt(
-        self,
-        topic_prompt: str,
-        language: str = "en",
-        use_rag: bool = False,
-        retriever=None,
+        self, topic_prompt: str, language: str = "en", retriever=None
     ):
-        """
-        Uses an LLM (optionally with RAG) to generate flashcards based on a topic prompt.
-        When ``use_rag`` is True, additional context from your indexed documents is
-        fetched and prepended to the prompt. If a ``retriever`` was supplied and
-        ``use_rag`` is ``True``, it is used via ``RetrievalQA`` for generation.
+        """Generate flashcards from a topic prompt.
+
+        Additional context is fetched only when a ``retriever`` is provided.
         """
         llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=0.5, verbose=True)
         retriever = retriever or self.retriever
 
-        def _fetch_context(inputs):
-            if retriever:
-                docs = retriever.get_relevant_documents(inputs["topic_prompt"])
-                ctx = "\n\n".join([doc.page_content for doc in docs])
-            else:
-                rag = RAGHandler()
-                rag.load_vectorstore()
-                ctx = rag.get_context(inputs["topic_prompt"], k=3)
-            return {**inputs, "context": ctx}
+        context = ""
+        if retriever:
+            docs = retriever.get_relevant_documents(topic_prompt)
+            context = "\n\n".join([doc.page_content for doc in docs])
 
-        def _skip_context(inputs):
-            return {**inputs, "context": ""}
-
-        branch = RunnableBranch(
-            (lambda d: d.get("use_rag", False), RunnableLambda(_fetch_context)),
-            RunnableLambda(_skip_context),
+        prompt = ""
+        if context:
+            prompt += context + "\n\n"
+        prompt += (
+            "You are an expert educator preparing students for a rigorous test or exam.\n"
+            f'Generate a high-quality, detailed list of flashcards for the topic: "{topic_prompt}".\n'
+            "The flashcards should include:\n"
+            "- definitions of core concepts\n"
+            "- names and explanations of key theorems or formulas\n"
+            "- concrete, technical facts that are often tested\n"
+            "- pay attention to the detailed domain knowledge needed by specialists at the level indicated by the user\n"
+            "Each flashcard must follow this format:\n"
+            "Q: [Clear, technical question]\n"
+            "A: [Precise, exam-focused answer]\n\n"
+            "Don't include explanations, examples, or anything besides flashcards.\n"
+            f"Respond in {language}."
         )
 
-        def _build_prompt(inputs):
-            context = inputs["context"]
-            topic = inputs["topic_prompt"]
-            prompt = ""
-            if context:
-                prompt += context + "\n\n"
-            prompt += (
-                f"You are an expert educator preparing students for a rigorous test or exam.\n"
-                f'Generate a high-quality, detailed list of flashcards for the topic: "{topic}".\n'
-                f"The flashcards should include:\n"
-                f"- definitions of core concepts\n"
-                f"- names and explanations of key theorems or formulas\n"
-                f"- concrete, technical facts that are often tested\n"
-                f"- pay attention to the detailed domain knowledge needed by specialists at the level indicated by the user\n"
-                f"Each flashcard must follow this format:\n"
-                f"Q: [Clear, technical question]\n"
-                f"A: [Precise, exam-focused answer]\n\n"
-                f"Don't include explanations, examples, or anything besides flashcards.\n"
-                f"Respond in {inputs['language']}."
-            )
-            return prompt
-
-        chain = RunnableSequence(branch, RunnableLambda(_build_prompt) | llm)
-
         try:
-            # Use any available retriever only when RAG is enabled
-            if use_rag and retriever:
+            if retriever:
                 qa = RetrievalQA.from_chain_type(
                     llm=llm, chain_type="stuff", retriever=retriever
                 )
                 raw_output = qa.run(topic_prompt)
             else:
-                response = chain.invoke(
-                    {
-                        "topic_prompt": topic_prompt,
-                        "language": language,
-                        "use_rag": use_rag,
-                    }
-                )
+                response = llm.invoke(prompt)
                 raw_output = response.content
 
             pairs = re.findall(

--- a/QuizModule/quiz_operations.py
+++ b/QuizModule/quiz_operations.py
@@ -8,22 +8,18 @@ from langchain_openai import ChatOpenAI
 from langchain.schema.runnable import RunnableLambda, RunnableParallel
 from LearningPlanModule.learning_plan import LearningPlan
 from tools.language_handler import LanguageHandler
-from RAGModule.rag import RAGHandler
 from tools.auto_answer import auto_answer
 
 
-def prepare_quiz_questions(subject: str, language: str = "en", use_rag: bool = False, retriever=None) -> list[dict]:
+def prepare_quiz_questions(
+    subject: str, language: str = "en", retriever=None
+) -> list[dict]:
     """Return a list of quiz questions without running an interactive loop."""
     llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=0.1, verbose=True)
 
     context = ""
-    if use_rag:
-        if retriever:
-            docs = retriever.get_relevant_documents(subject)
-        else:
-            rag = RAGHandler()
-            rag.load_vectorstore()
-            docs = rag.semantic_search(subject, k=3)
+    if retriever:
+        docs = retriever.get_relevant_documents(subject)
         context = "\n\n".join([doc.page_content for doc in docs])
 
     prompt_subject = subject
@@ -46,19 +42,19 @@ def prepare_quiz_questions(subject: str, language: str = "en", use_rag: bool = F
     questions_per_topic = max_questions // max_topics
 
     # Generate questions in parallel
-    if use_rag:
-        if retriever:
-            context_chain = RunnableLambda(
-                lambda inputs: "\n\n".join(
-                    [doc.page_content for doc in retriever.get_relevant_documents(inputs["topic"])]
-                )
+    if retriever:
+        context_chain = RunnableLambda(
+            lambda inputs: "\n\n".join(
+                [
+                    doc.page_content
+                    for doc in retriever.get_relevant_documents(inputs["topic"])
+                ]
             )
-        else:
-            rag = RAGHandler()
-            rag.load_vectorstore()
-            context_chain = RunnableLambda(lambda inputs: rag.get_context(inputs["topic"], k=3))
+        )
         prompt_chain = RunnableLambda(
-            lambda inputs: generate_questions_prompt(inputs["topic"], language=language).format_prompt(topic=inputs["topic"])
+            lambda inputs: generate_questions_prompt(
+                inputs["topic"], language=language
+            ).format_prompt(topic=inputs["topic"])
         )
         question_chain = (
             RunnableParallel({"ctx": context_chain, "prompt": prompt_chain})
@@ -67,7 +63,9 @@ def prepare_quiz_questions(subject: str, language: str = "en", use_rag: bool = F
         )
     else:
         question_chain = RunnableLambda(
-            lambda inputs: generate_questions_prompt(inputs["topic"], language=language).format_prompt(topic=inputs["topic"])
+            lambda inputs: generate_questions_prompt(
+                inputs["topic"], language=language
+            ).format_prompt(topic=inputs["topic"])
         ) | llm
 
     question_sets = question_chain.batch([{"topic": t} for t in topics])
@@ -83,10 +81,10 @@ def prepare_quiz_questions(subject: str, language: str = "en", use_rag: bool = F
 
     return questions_list
 
-def generate_quiz(subject: str, language: str = "en", use_rag: bool = False, retriever=None):
+def generate_quiz(subject: str, language: str = "en", retriever=None):
     """Run an interactive quiz in the terminal and return the results."""
     try:
-        questions = prepare_quiz_questions(subject, language=language, use_rag=use_rag, retriever=retriever)
+        questions = prepare_quiz_questions(subject, language=language, retriever=retriever)
         if not questions:
             print("\u26a0\ufe0f No quiz topics generated.")
             return {}

--- a/SummaryModule/summary_generator.py
+++ b/SummaryModule/summary_generator.py
@@ -1,8 +1,6 @@
 from langchain_openai import ChatOpenAI
 from langchain_core.prompts import PromptTemplate
 from tools.language_handler import LanguageHandler
-from langchain.schema.runnable import RunnableLambda, RunnableBranch, RunnableSequence
-from RAGModule.rag import RAGHandler
 
 # TODO: optimize with pipeline, quering, give more detailed contents, maybe more examples :  with ML prompt there are no examples of algorithms ect. 
 
@@ -51,42 +49,22 @@ Respond in {language}.
         ) 
 
     def generate_summary(
-        self,
-        input_text: str,
-        language: str = "en",
-        use_rag: bool = False,
-        retriever=None
+        self, input_text: str, language: str = "en", retriever=None
     ) -> str:
-        """
-        Generate a detailed study summary using the configured LLM and prompt.
-        If ``use_rag`` is True, an external ``retriever`` can be supplied for
-        context; otherwise a new :class:`RAGHandler` will be used.
-        """
-        lang = LanguageHandler.choose_or_detect(input_text) if language == "auto" else language
-
-        retriever = retriever or self.retriever
-
-        def _fetch_context(inputs):
-            if retriever:
-                """Retrieve additional context using RAG if a retriever is provided."""
-                docs = retriever.get_relevant_documents(inputs["input"])
-                ctx = "\n\n".join([doc.page_content for doc in docs])
-            else:
-                rag = RAGHandler()
-                rag.load_vectorstore()
-                ctx = rag.get_context(inputs["input"], k=3)
-            inputs["input"] = f"{ctx}\n\n### Topic:\n{inputs['input']}"
-            return inputs
-
-        def _skip_context(inputs):
-            return inputs
-
-        branch = RunnableBranch(
-            (lambda d: d.get("use_rag", False), RunnableLambda(_fetch_context)),
-            RunnableLambda(_skip_context)
+        """Generate a detailed study summary using the configured LLM and prompt."""
+        lang = (
+            LanguageHandler.choose_or_detect(input_text)
+            if language == "auto"
+            else language
         )
 
-        chain = RunnableSequence(branch, self.base_prompt | self.llm)
+        retriever = retriever or self.retriever
+        prompt_inputs = {"input": input_text, "language": lang}
 
-        response = chain.invoke({"input": input_text, "language": lang, "use_rag": use_rag})
+        if retriever:
+            docs = retriever.get_relevant_documents(input_text)
+            ctx = "\n\n".join([doc.page_content for doc in docs])
+            prompt_inputs["input"] = f"{ctx}\n\n### Topic:\n{input_text}"
+
+        response = (self.base_prompt | self.llm).invoke(prompt_inputs)
         return response.content

--- a/frontend_service/interface.py
+++ b/frontend_service/interface.py
@@ -136,11 +136,15 @@ def _format_question(q: dict) -> str:
     return f"**{q['topic']}**\n\n{text}"
 
 
-def start_quiz(subject: str, use_rag: bool, lang_choice: str) -> tuple[str, dict, str]:
+def start_quiz(
+    subject: str, lang_choice: str, retriever=None
+) -> tuple[str, dict, str]:
     """Generate quiz questions and return the first one with state."""
     code = LanguageHandler.code_from_display(lang_choice)
     language = code if code != "auto" else LanguageHandler.choose_or_detect(subject)
-    questions = prepare_quiz_questions(subject, language=language, use_rag=use_rag)
+    questions = prepare_quiz_questions(
+        subject, language=language, retriever=retriever
+    )
     if not questions:
         return "Failed to generate quiz.", {}, ""
     state = {
@@ -248,16 +252,16 @@ def _render_flashcard(state: dict) -> str:
 
 
 def run_flashcards_generate(
-    topic: str, use_rag: bool, lang_choice: str
+    topic: str, lang_choice: str, retriever=None
 ) -> tuple[str, dict, str, str]:
     """Generate flashcards from a topic and prepare viewer state."""
     code = LanguageHandler.code_from_display(lang_choice)
     language = code if code != "auto" else LanguageHandler.choose_or_detect(topic)
-    flashcards = FlashcardSet(topic)
+    flashcards = FlashcardSet(topic, retriever=retriever)
     buffer = io.StringIO()
     with redirect_stdout(buffer):
         flashcards.generate_from_prompt(
-            topic_prompt=topic, language=language, use_rag=use_rag
+            topic_prompt=topic, language=language, retriever=retriever
         )
         path = flashcards.save_to_file()
     logs = buffer.getvalue()
@@ -326,20 +330,26 @@ def flashcard_shuffle(state: dict) -> tuple[str, dict, str]:
     return _render_flashcard(state), state, f"1/{len(state['cards'])}"
 
 
-def run_summary_interface(topic: str, use_rag: bool, lang_choice: str) -> str:
+def run_summary_interface(
+    topic: str, lang_choice: str, retriever=None
+) -> str:
     """Generate a detailed study summary."""
     code = LanguageHandler.code_from_display(lang_choice)
     language = code if code != "auto" else LanguageHandler.choose_or_detect(topic)
-    summarizer = StudySummaryGenerator()
-    return summarizer.generate_summary(topic, language=language, use_rag=use_rag)
+    summarizer = StudySummaryGenerator(retriever=retriever)
+    return summarizer.generate_summary(topic, language=language, retriever=retriever)
 
 
-def run_cheatsheet_interface(topic: str, use_rag: bool, lang_choice: str) -> str:
+def run_cheatsheet_interface(
+    topic: str, lang_choice: str, retriever=None
+) -> str:
     """Generate a cheat sheet."""
     code = LanguageHandler.code_from_display(lang_choice)
     language = code if code != "auto" else LanguageHandler.choose_or_detect(topic)
-    generator = CheatSheetGenerator()
-    return generator.generate_cheatsheet(topic, language=language, use_rag=use_rag)
+    generator = CheatSheetGenerator(retriever=retriever)
+    return generator.generate_cheatsheet(
+        topic, language=language, retriever=retriever
+    )
 
 
 def build_interface() -> gr.Blocks:
@@ -375,7 +385,6 @@ def build_interface() -> gr.Blocks:
             # Quiz tab
             with gr.TabItem("Generate quiz"):
                 quiz_subject = gr.Textbox(label="Subject")
-                quiz_rag = gr.Checkbox(label="Use RAG", value=False)
                 start_btn = gr.Button("Start Quiz")
                 quiz_question = gr.Markdown()
                 with gr.Row():
@@ -391,7 +400,7 @@ def build_interface() -> gr.Blocks:
 
                 start_btn.click(
                     start_quiz,
-                    [quiz_subject, quiz_rag, lang_select],
+                    [quiz_subject, lang_select],
                     [quiz_question, quiz_state, quiz_result],
                 )
                 btn_a.click(
@@ -436,7 +445,6 @@ def build_interface() -> gr.Blocks:
             with gr.TabItem("Flashcards"):
                 with gr.Accordion("Generate flashcards", open=True):
                     fc_topic = gr.Textbox(label="Topic")
-                    fc_rag = gr.Checkbox(label="Use RAG", value=False)
                     fc_gen_btn = gr.Button("Generate")
                     with gr.Column(elem_id="flashcard-container"):
                         fc_card = gr.Markdown(elem_id="flashcard-content")
@@ -451,7 +459,7 @@ def build_interface() -> gr.Blocks:
 
                     fc_gen_btn.click(
                         run_flashcards_generate,
-                        [fc_topic, fc_rag, lang_select],
+                        [fc_topic, lang_select],
                         [fc_card, fc_state, fc_logs, fc_counter],
                         show_progress=False,
                     )
@@ -493,21 +501,19 @@ def build_interface() -> gr.Blocks:
             # Summary tab
             with gr.TabItem("Summary"):
                 sum_topic = gr.Textbox(label="Topic or material")
-                sum_rag = gr.Checkbox(label="Use RAG", value=False)
                 sum_btn = gr.Button("Generate Summary")
                 sum_output = gr.Textbox(label="Summary", lines=10)
                 sum_btn.click(
-                    run_summary_interface, [sum_topic, sum_rag, lang_select], sum_output
+                    run_summary_interface, [sum_topic, lang_select], sum_output
                 )
 
             # Cheat sheet tab
             with gr.TabItem("Cheat sheet"):
                 cs_topic = gr.Textbox(label="Topic or material")
-                cs_rag = gr.Checkbox(label="Use RAG", value=False)
                 cs_btn = gr.Button("Generate Cheat Sheet")
                 cs_output = gr.Textbox(label="Cheat Sheet", lines=10)
                 cs_btn.click(
-                    run_cheatsheet_interface, [cs_topic, cs_rag, lang_select], cs_output
+                    run_cheatsheet_interface, [cs_topic, lang_select], cs_output
                 )
 
     return demo

--- a/main.py
+++ b/main.py
@@ -134,7 +134,9 @@ def main_menu():
                 == "y"
             )
             generate_quiz(
-                subject, language=language, use_rag=use_rag, retriever=retriever
+                subject,
+                language=language,
+                retriever=retriever if use_rag else None,
             )
 
         elif choice == "3":
@@ -153,7 +155,9 @@ def main_menu():
                     == "y"
                 )
                 quiz_results = generate_quiz(
-                    subject, language=language, use_rag=use_rag, retriever=retriever
+                    subject,
+                    language=language,
+                    retriever=retriever if use_rag else None,
                 )
                 user_name = prompt_input("Enter your name: ")
                 generate_learning_plan_from_quiz(user_name, quiz_results, language)
@@ -176,19 +180,19 @@ def main_menu():
         elif choice == "4":
             topic = prompt_input("Enter a topic for flashcard generation: ")
             language = LanguageHandler.choose_or_detect(topic)
-            # pass retriever to flashcards
-            flashcards = FlashcardSet(topic, retriever=retriever)
             use_rag = (
                 prompt_input("Enrich flashcards with your documents? (y/N): ")
                 .strip()
                 .lower()
                 == "y"
             )
+            flashcards = FlashcardSet(
+                topic, retriever=retriever if use_rag else None
+            )
             flashcards.generate_from_prompt(
                 topic_prompt=topic,
                 language=language,
-                use_rag=use_rag,
-                retriever=retriever,
+                retriever=retriever if use_rag else None,
             )
             print(flashcards.to_dict_list())
             flashcards.save_to_file()
@@ -202,16 +206,19 @@ def main_menu():
         elif choice == "6":
             topic = prompt_input("Enter the topic or material for TL;DR summary: ")
             language = LanguageHandler.choose_or_detect(topic)
-            # pass retriever to summary
-            summarizer = StudySummaryGenerator(retriever=retriever)
             use_rag = (
                 prompt_input("Enrich summary with your documents? (y/N): ")
                 .strip()
                 .lower()
                 == "y"
             )
+            summarizer = StudySummaryGenerator(
+                retriever=retriever if use_rag else None
+            )
             summary = summarizer.generate_summary(
-                topic, language=language, use_rag=use_rag, retriever=retriever
+                topic,
+                language=language,
+                retriever=retriever if use_rag else None,
             )
             print("\n📘 Summary:\n")
             print(summary)
@@ -219,16 +226,19 @@ def main_menu():
         elif choice == "7":
             topic = prompt_input("Enter the topic or material for the cheat sheet: ")
             language = LanguageHandler.choose_or_detect(topic)
-            # pass retriever to cheat sheet generator
-            generator = CheatSheetGenerator(retriever=retriever)
             use_rag = (
                 prompt_input("Enrich cheat sheet with your documents? (y/N): ")
                 .strip()
                 .lower()
                 == "y"
             )
+            generator = CheatSheetGenerator(
+                retriever=retriever if use_rag else None
+            )
             cheatsheet = generator.generate_cheatsheet(
-                topic, language=language, use_rag=use_rag, retriever=retriever
+                topic,
+                language=language,
+                retriever=retriever if use_rag else None,
             )
             print("\n📄 Cheat Sheet:\n")
             print(cheatsheet)


### PR DESCRIPTION
## Summary
- simplify quiz start by dropping `use_rag` flag and using optional retriever
- remove RAG checkboxes from UI and interface functions, passing retriever only when available
- update generation modules to fetch context solely when a retriever is supplied

## Testing
- `python -m py_compile frontend_service/interface.py FlashcardsModule/flashcards.py SummaryModule/summary_generator.py CheatSheetModule/cheatsheet_generator.py QuizModule/quiz_operations.py main.py`
- `pre-commit run --files frontend_service/interface.py FlashcardsModule/flashcards.py SummaryModule/summary_generator.py CheatSheetModule/cheatsheet_generator.py QuizModule/quiz_operations.py main.py` *(fails: .pre-commit-config.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_6891e010d88c8323b836be14e2f08041