### PR TITLE
Explicitly pass retriever arg in summary calls

### DIFF
--- a/frontend_service/interface.py
+++ b/frontend_service/interface.py
@@ -329,7 +329,7 @@ def run_summary_interface(topic: str, lang_choice: str) -> str:
     code = LanguageHandler.code_from_display(lang_choice)
     language = code if code != "auto" else LanguageHandler.choose_or_detect(topic)
     summarizer = StudySummaryGenerator()
-    return summarizer.generate_summary(topic, language=language)
+    return summarizer.generate_summary(topic, language=language, retriever=None)
 
 
 def run_cheatsheet_interface(topic: str, lang_choice: str) -> str:

--- a/main.py
+++ b/main.py
@@ -149,7 +149,9 @@ def main_menu():
             topic = prompt_input("Enter the topic or material for TL;DR summary: ")
             language = LanguageHandler.choose_or_detect(topic)
             summarizer = StudySummaryGenerator()
-            summary = summarizer.generate_summary(topic, language=language)
+            summary = summarizer.generate_summary(
+                topic, language=language, retriever=None
+            )
             print("\n📘 Summary:\n")
             print(summary)
 


### PR DESCRIPTION
## Summary
- Explicitly pass the new `retriever` argument (set to `None`) when invoking `generate_summary` from the CLI and Gradio interface.
- `StudySummaryGenerator.generate_summary` already supports `language` and optional `retriever` parameters with a simple document fetch block.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689211b5d36c8323a2fefcc3208b8d3d