### PR TITLE
Clarify optional retrieval in CheatSheetGenerator

### DIFF
--- a/CheatSheetModule/cheatsheet_generator.py
+++ b/CheatSheetModule/cheatsheet_generator.py
@@ -63,6 +63,7 @@ Respond only in {language}.
         retriever = retriever or self.retriever
 
         ctx = ""
+        # Perform retrieval-augmented generation only when a retriever is provided
         if retriever:
             docs = retriever.get_relevant_documents(input_text)
             ctx = "\n\n".join(d.page_content for d in docs)


### PR DESCRIPTION
## Summary
- document that cheat sheet generation only performs retrieval when a retriever is provided

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689211b4e9dc8323a82d5a8fe0181735