### PR TITLE
Allow optional retrieval without RAG toggles

### DIFF
--- a/frontend_service/interface.py
+++ b/frontend_service/interface.py
@@ -136,11 +136,15 @@ def _format_question(q: dict) -> str:
     return f"**{q['topic']}**\n\n{text}"
 
 
-def start_quiz(subject: str, lang_choice: str) -> tuple[str, dict, str]:
+def start_quiz(
+    subject: str, lang_choice: str, retriever=None
+) -> tuple[str, dict, str]:
     """Generate quiz questions and return the first one with state."""
     code = LanguageHandler.code_from_display(lang_choice)
     language = code if code != "auto" else LanguageHandler.choose_or_detect(subject)
-    questions = prepare_quiz_questions(subject, language=language)
+    questions = prepare_quiz_questions(
+        subject, language=language, retriever=retriever
+    )
     if not questions:
         return "Failed to generate quiz.", {}, ""
     state = {
@@ -248,12 +252,12 @@ def _render_flashcard(state: dict) -> str:
 
 
 def run_flashcards_generate(
-    topic: str, lang_choice: str
+    topic: str, lang_choice: str, retriever=None
 ) -> tuple[str, dict, str, str]:
     """Generate flashcards from a topic and prepare viewer state."""
     code = LanguageHandler.code_from_display(lang_choice)
     language = code if code != "auto" else LanguageHandler.choose_or_detect(topic)
-    flashcards = FlashcardSet(topic)
+    flashcards = FlashcardSet(topic, retriever=retriever)
     buffer = io.StringIO()
     with redirect_stdout(buffer):
         flashcards.generate_from_prompt(topic_prompt=topic, language=language)
@@ -324,19 +328,19 @@ def flashcard_shuffle(state: dict) -> tuple[str, dict, str]:
     return _render_flashcard(state), state, f"1/{len(state['cards'])}"
 
 
-def run_summary_interface(topic: str, lang_choice: str) -> str:
+def run_summary_interface(topic: str, lang_choice: str, retriever=None) -> str:
     """Generate a detailed study summary."""
     code = LanguageHandler.code_from_display(lang_choice)
     language = code if code != "auto" else LanguageHandler.choose_or_detect(topic)
-    summarizer = StudySummaryGenerator()
-    return summarizer.generate_summary(topic, language=language, retriever=None)
+    summarizer = StudySummaryGenerator(retriever=retriever)
+    return summarizer.generate_summary(topic, language=language)
 
 
-def run_cheatsheet_interface(topic: str, lang_choice: str) -> str:
+def run_cheatsheet_interface(topic: str, lang_choice: str, retriever=None) -> str:
     """Generate a cheat sheet."""
     code = LanguageHandler.code_from_display(lang_choice)
     language = code if code != "auto" else LanguageHandler.choose_or_detect(topic)
-    generator = CheatSheetGenerator()
+    generator = CheatSheetGenerator(retriever=retriever)
     return generator.generate_cheatsheet(topic, language=language)
 
 


### PR DESCRIPTION
## Summary
- Accept an optional retriever in quiz, flashcard, summary, and cheatsheet flows instead of boolean `use_rag`
- Simplify generation calls so context is only fetched when a retriever is provided

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689213e55aac8323a5338b20f6073968