### PR TITLE
Add tests for language, tools, and agent fallback logic

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,9 @@ tenacity==8.5.0
 pydantic==2.10.5
 pydantic-core==2.27.2
 
+# Testing
+pytest==8.3.2
+
 # RAG dependencies
 chromadb>=0.4.0
 langchain-chroma

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+import tools.language_handler as lh
+
+@pytest.fixture
+def temp_config_path(tmp_path, monkeypatch):
+    config = tmp_path / "user_config.json"
+    monkeypatch.setattr(lh, "CONFIG_PATH", str(config))
+    return config

--- a/tests/test_auto_answer.py
+++ b/tests/test_auto_answer.py
@@ -1,0 +1,16 @@
+import pytest
+from tools import auto_answer
+import tools.language_handler as lh
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [("Is this working?", True), ("This is a statement.", False)],
+)
+def test_looks_like_question_mark(text, expected):
+    assert auto_answer.looks_like_question(text) is expected
+
+
+def test_looks_like_question_word(monkeypatch):
+    monkeypatch.setattr(lh.LanguageHandler, "detect_language", lambda text: "pl")
+    assert auto_answer.looks_like_question("Kto to jest")

--- a/tests/test_edu_agent.py
+++ b/tests/test_edu_agent.py
@@ -1,0 +1,43 @@
+import pytest
+import AgentModule.edu_agent as ea
+import tools.language_handler as lh
+
+
+class DummyExecutor:
+    def __init__(self, output):
+        self.output = output
+
+    def invoke(self, inputs):
+        return {"output": self.output}
+
+
+class FakeLLM:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def invoke(self, prompt):
+        class Msg:
+            content = "Fallback answer"
+        return Msg()
+
+
+@pytest.fixture
+def patched_agent(monkeypatch):
+    monkeypatch.setattr(lh.LanguageHandler, "choose_or_detect", lambda text: "en")
+    monkeypatch.setattr(lh.LanguageHandler, "ensure_language", lambda text, lang: text)
+    monkeypatch.setattr(ea, "ChatOpenAI", FakeLLM)
+    return lambda output: DummyExecutor(output)
+
+
+def test_run_agent_no_fallback(patched_agent):
+    executor = patched_agent("The capital is Warsaw")
+    output, used_fallback = ea.run_agent("Question", executor=executor, return_details=True)
+    assert output == "The capital is Warsaw"
+    assert used_fallback is False
+
+
+def test_run_agent_with_fallback(patched_agent):
+    executor = patched_agent("error: something broke")
+    output, used_fallback = ea.run_agent("Question", executor=executor, return_details=True)
+    assert output == "Fallback answer"
+    assert used_fallback is True

--- a/tests/test_edu_tools.py
+++ b/tests/test_edu_tools.py
@@ -1,0 +1,50 @@
+import re
+import tools.language_handler as lh
+from tools import edu_tools as et
+
+
+def test_define_word(monkeypatch):
+    class FakeWN:
+        def synsets(self, word):
+            class FakeSynset:
+                def __init__(self, definition):
+                    self._def = definition
+
+                def definition(self):
+                    return self._def
+
+            if word == "dog":
+                return [FakeSynset("a domesticated canine")]
+            return []
+
+    monkeypatch.setattr(et, "wn", FakeWN())
+    assert et.define_word.invoke("dog") == "a domesticated canine"
+    assert et.define_word.invoke("asdfghjkl") == "No definition found."
+
+
+def test_calculator():
+    assert et.calculator("1 + 2*3") == "7"
+    assert "Error" in et.calculator("1/0")
+
+
+def test_current_date_format():
+    date_str = et.current_date.invoke("")
+    assert re.match(r"\d{4}-\d{2}-\d{2}", date_str)
+
+
+def test_current_weekday():
+    weekday = et.current_weekday.invoke("")
+    assert weekday in [
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday",
+        "Saturday",
+        "Sunday",
+    ]
+
+
+def test_detect_language(monkeypatch):
+    monkeypatch.setattr(lh.LanguageHandler, "detect_language", lambda text: "xx")
+    assert et.detect_language("hello") == "xx"

--- a/tests/test_flashcards.py
+++ b/tests/test_flashcards.py
@@ -1,0 +1,49 @@
+import FlashcardsModule.flashcards as fc
+from langchain.schema.runnable import Runnable
+
+
+class FakeLLM(Runnable):
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def invoke(self, prompt, config=None):
+        class Msg:
+            content = (
+                "Q: Capital of France?\nA: Paris\n"
+                "Q: 2+2?\nA: 4"
+            )
+        return Msg()
+
+    def batch(self, prompts, config=None, **kwargs):
+        return [self.invoke(p) for p in prompts]
+
+
+def test_generate_from_prompt(monkeypatch):
+    monkeypatch.setattr(fc, "ChatOpenAI", FakeLLM)
+    flashcards = fc.FlashcardSet("geo")
+    flashcards.generate_from_prompt("geography")
+    assert flashcards.flashcards[0].question == "Capital of France?"
+    assert flashcards.flashcards[0].answer == "Paris"
+    assert len(flashcards.flashcards) == 2
+
+
+def test_generate_from_quiz_text():
+    raw = (
+        "Question: What is 2+2?\n"
+        "a) 3\n"
+        "b) 4\n"
+        "c) 5\n"
+        "d) 22\n"
+        "Correct Answer: b\n\n"
+        "Question: Capital of Italy?\n"
+        "a) Rome\n"
+        "b) Madrid\n"
+        "c) Paris\n"
+        "d) Berlin\n"
+        "Correct Answer: a"
+    )
+    fs = fc.FlashcardSet("math")
+    fs.generate_from_quiz_text(raw)
+    assert len(fs.flashcards) == 2
+    assert fs.flashcards[0].question == "What is 2+2?"
+    assert fs.flashcards[0].answer == "4"

--- a/tests/test_language_handler.py
+++ b/tests/test_language_handler.py
@@ -1,0 +1,35 @@
+import os
+import json
+import re
+import tools.language_handler as lh
+from tools.language_handler import LanguageHandler
+
+
+def test_set_get_and_choose_language(temp_config_path):
+    LanguageHandler.set_language("en")
+    assert LanguageHandler.get_language() == "en"
+    LanguageHandler.set_language("auto")
+    lang = LanguageHandler.choose_or_detect("Cześć")
+    assert lang == "pl"
+
+
+def test_ensure_language_translates(monkeypatch):
+    monkeypatch.setattr(LanguageHandler, "detect_language", lambda text: "pl")
+
+    class DummyTranslator:
+        def __init__(self, source="auto", target="en"):
+            self.source = source
+            self.target = target
+
+        def translate(self, text: str) -> str:
+            return "hello"
+
+    monkeypatch.setattr(lh, "GoogleTranslator", DummyTranslator)
+    result = LanguageHandler.ensure_language("cześć", "en")
+    assert result == "hello"
+
+
+def test_ensure_language_no_translation(monkeypatch):
+    monkeypatch.setattr(LanguageHandler, "detect_language", lambda text: "en")
+    result = LanguageHandler.ensure_language("hello", "en")
+    assert result == "hello"

--- a/tests/test_quiz_operations.py
+++ b/tests/test_quiz_operations.py
@@ -1,0 +1,42 @@
+import QuizModule.quiz_operations as qo
+from langchain.schema.runnable import Runnable
+
+
+class FakeLLM(Runnable):
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def invoke(self, prompt, config=None):
+        class Msg:
+            content = "Algebra\nGeometry"
+        return Msg()
+
+    def batch(self, prompts, config=None, **kwargs):
+        return [type("Msg", (), {"content": "What is 2+2?\nCorrect Answer: a"}) for _ in prompts]
+
+
+def test_prepare_quiz_questions(monkeypatch):
+    monkeypatch.setattr(qo, "ChatOpenAI", FakeLLM)
+    questions = qo.prepare_quiz_questions("math")
+    assert questions == [
+        {"topic": "Algebra", "question": "What is 2+2?", "correct": "a"},
+        {"topic": "Geometry", "question": "What is 2+2?", "correct": "a"},
+    ]
+
+
+class EmptyLLM(Runnable):
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def invoke(self, prompt, config=None):
+        class Msg:
+            content = ""
+        return Msg()
+
+    def batch(self, prompts, config=None, **kwargs):
+        return []
+
+
+def test_prepare_quiz_questions_no_topics(monkeypatch):
+    monkeypatch.setattr(qo, "ChatOpenAI", EmptyLLM)
+    assert qo.prepare_quiz_questions("history") == []


### PR DESCRIPTION
## Summary
- Add comprehensive unit tests for LanguageHandler language detection and translation
- Verify core edu tools like word definition, calculator, and date/weekday utilities
- Test auto-answer question heuristics and agent fallback behavior with mocked LLM

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68922813222883239b1379acf95ad362