### PR TITLE
Add CLI tool for RAG ingestion with deduplication

### DIFF
--- a/tools/ingest.py
+++ b/tools/ingest.py
@@ -1,0 +1,81 @@
+"""CLI utility to ingest documents into the RAG vector store."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import List
+
+from langchain_core.documents import Document
+from langchain_community.document_loaders import (
+    CSVLoader,
+    PyPDFLoader,
+    TextLoader,
+    UnstructuredEPubLoader,
+    UnstructuredHTMLLoader,
+    UnstructuredMarkdownLoader,
+    UnstructuredPowerPointLoader,
+    UnstructuredWordDocumentLoader,
+    UnstructuredFileLoader,
+)
+from langchain_text_splitters import RecursiveCharacterTextSplitter
+
+from tools.rag_service import get_rag_service
+
+
+LOADERS = {
+    ".txt": TextLoader,
+    ".md": UnstructuredMarkdownLoader,
+    ".markdown": UnstructuredMarkdownLoader,
+    ".pdf": PyPDFLoader,
+    ".docx": UnstructuredWordDocumentLoader,
+    ".pptx": UnstructuredPowerPointLoader,
+    ".html": UnstructuredHTMLLoader,
+    ".htm": UnstructuredHTMLLoader,
+    ".csv": CSVLoader,
+    ".epub": UnstructuredEPubLoader,
+}
+
+
+def load_file(path: Path) -> List[Document]:
+    """Load ``path`` into a list of Documents using an appropriate loader."""
+    loader_cls = LOADERS.get(path.suffix.lower())
+    if loader_cls is None:
+        loader = UnstructuredFileLoader(str(path))
+    else:
+        loader = loader_cls(str(path))
+    docs = loader.load()
+    for doc in docs:
+        doc.metadata["source"] = str(path)
+    return docs
+
+
+def ingest_folder(folder: str = "data/RAG_files") -> None:
+    """Ingest all files from ``folder`` into the RAG vector store."""
+    rag = get_rag_service()
+    all_docs: List[Document] = []
+    folder_path = Path(folder)
+    for file_path in folder_path.glob("**/*"):
+        if file_path.is_file():
+            all_docs.extend(load_file(file_path))
+    if not all_docs:
+        return
+    splitter = RecursiveCharacterTextSplitter()
+    chunks = splitter.split_documents(all_docs)
+    rag.ingest_paths(chunks)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Ingest documents into RAG store")
+    parser.add_argument(
+        "folder",
+        nargs="?",
+        default="data/RAG_files",
+        help="Folder containing documents to ingest",
+    )
+    args = parser.parse_args()
+    ingest_folder(args.folder)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/rag_service.py
+++ b/tools/rag_service.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
-from typing import Optional, Tuple
+from typing import Iterable, Optional, Tuple, Union
 
 from langchain_chroma import Chroma
 from langchain_openai import OpenAIEmbeddings
+from langchain_core.documents import Document
 from langchain_community.document_loaders import UnstructuredFileLoader
+from hashlib import sha256
 
 
 class RAGService:
@@ -37,15 +39,37 @@ class RAGService:
             self._retriever_params = params
         return self._retriever
 
-    def ingest_paths(self, paths: list[str]) -> None:
-        """Embed documents from ``paths`` into the vector store and persist."""
+    def ingest_paths(self, items: Iterable[Union[str, Document]]) -> None:
+        """Embed documents from ``items`` into the vector store and persist.
+
+        ``items`` may be file paths or :class:`~langchain_core.documents.Document`
+        instances. Chunks are deduplicated using a ``doc_hash`` metadata field to
+        avoid embedding the same content multiple times.
+        """
         store = self._get_vectorstore()
-        documents = []
-        for path in paths:
-            loader = UnstructuredFileLoader(path)
-            documents.extend(loader.load())
-        if documents:
-            store.add_documents(documents)
+        documents: list[Document] = []
+        for item in items:
+            if isinstance(item, str):
+                loader = UnstructuredFileLoader(item)
+                documents.extend(loader.load())
+            else:
+                documents.append(item)
+
+        to_add: list[Document] = []
+        seen_hashes: set[str] = set()
+        for doc in documents:
+            doc_hash = doc.metadata.get("doc_hash") or sha256(
+                doc.page_content.encode("utf-8")
+            ).hexdigest()
+            doc.metadata["doc_hash"] = doc_hash
+            if doc_hash in seen_hashes:
+                continue
+            seen_hashes.add(doc_hash)
+            if not store.get(where={"doc_hash": doc_hash}, limit=1)["ids"]:
+                to_add.append(doc)
+
+        if to_add:
+            store.add_documents(to_add)
             store.persist()
 
 


### PR DESCRIPTION
## Summary
- Add `tools/ingest.py` script to load, split, and ingest documents from a folder
- Enhance `RAGService.ingest_paths` to accept document chunks or paths and skip duplicate embeddings via metadata hashes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68926c227274832394a82bbf4e8841a6