### PR TITLE
Initialize RAG retriever and handle empty context across modules

### DIFF
--- a/CheatSheetModule/cheatsheet_generator.py
+++ b/CheatSheetModule/cheatsheet_generator.py
@@ -1,5 +1,6 @@
 from langchain_openai import ChatOpenAI
 from langchain_core.prompts import PromptTemplate
+from tools.rag_service import RAGService
 
 # TODO: test and optimize
 
@@ -10,6 +11,8 @@ class CheatSheetGenerator:
     """
     def __init__(self, model_name="gpt-3.5-turbo", temperature=0.3, retriever=None):
         self.llm = ChatOpenAI(model=model_name, temperature=temperature)
+        if retriever is None:
+            retriever = RAGService().get_retriever()
         self.retriever = retriever  # optional document retriever
 
         # Based on the RStudio cheatsheet guidelines which suggest designing
@@ -61,12 +64,15 @@ Respond only in {language}.
             Generated cheat sheet as string.
         """
         retriever = retriever or self.retriever
+        if retriever is None:
+            retriever = RAGService().get_retriever()
 
         ctx = ""
         # Perform retrieval-augmented generation only when a retriever is provided
         if retriever:
-            docs = retriever.invoke(input_text)
-            ctx = "\n\n".join(d.page_content for d in docs)
+            docs = retriever.get_relevant_documents(input_text)
+            if docs:
+                ctx = "\n\n".join(d.page_content for d in docs)
 
         response = (self.prompt | self.llm).invoke(
             {"input": input_text, "language": language, "context": ctx}

--- a/FlashcardsModule/flashcards.py
+++ b/FlashcardsModule/flashcards.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from langchain.schema.runnable import RunnableLambda
 from langchain_openai import ChatOpenAI
 from tools.auto_answer import auto_answer
+from tools.rag_service import RAGService
 
 
 class Flashcard:
@@ -33,6 +34,8 @@ class FlashcardSet:
     def __init__(self, topic: str, flashcards=None, retriever=None):
         self.topic = topic.strip()
         self.flashcards = flashcards if flashcards else []
+        if retriever is None:
+            retriever = RAGService().get_retriever()
         self.retriever = retriever  # optional document retriever
 
     def add_flashcard(self, flashcard: Flashcard):
@@ -71,11 +74,14 @@ class FlashcardSet:
         """
         llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=0.5, verbose=True)
         retriever = retriever or self.retriever
+        if retriever is None:
+            retriever = RAGService().get_retriever()
 
         ctx = ""
         if retriever:
-            docs = retriever.invoke(topic_prompt)
-            ctx = "\n\n".join(d.page_content for d in docs)
+            docs = retriever.get_relevant_documents(topic_prompt)
+            if docs:
+                ctx = "\n\n".join(d.page_content for d in docs)
 
         def _build_prompt(inputs):
             context = inputs["context"]

--- a/LearningPlanModule/learning_plan.py
+++ b/LearningPlanModule/learning_plan.py
@@ -2,17 +2,23 @@ import json
 import os
 from datetime import date, timedelta, datetime
 from langchain_openai import ChatOpenAI
+from tools.rag_service import RAGService
 
 # TODO: use cases from prompts for edu
 
 class LearningPlan:
-    def __init__(self, user_name, quiz_results=None, user_goals=None, user_language="en"):
+    def __init__(
+        self, user_name, quiz_results=None, user_goals=None, user_language="en", retriever=None
+    ):
         self.user_name = user_name
         self.quiz_results = quiz_results if quiz_results else {}
         self.user_goals = user_goals if user_goals else {}
         self.user_language = user_language
         self.learning_plan = []
-        self.llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=0.7, verbose=True)  # Użycie ChatOpenAI
+        self.llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=0.7, verbose=True)
+        if retriever is None:
+            retriever = RAGService().get_retriever()
+        self.retriever = retriever
 
     def analyze_quiz_results(self):
         """
@@ -77,20 +83,31 @@ class LearningPlan:
         self.learning_plan = plan
         return plan
 
-    def recommend_materials(self, topic):
+    def recommend_materials(self, topic, retriever=None):
         """
-        Retrieve recommended materials for a given topic using LLM.
+        Retrieve recommended materials for a given topic using LLM and optional RAG context.
         The response should prioritize materials in the user's language,
         but can include English resources as fallback.
         """
+        retriever = retriever or self.retriever
+        if retriever is None:
+            retriever = RAGService().get_retriever()
+
+        ctx = ""
+        if retriever:
+            docs = retriever.get_relevant_documents(topic)
+            if docs:
+                ctx = "\n\n".join(d.page_content for d in docs) + "\n\n"
+
         prompt = (
+            f"{ctx}"  # prepend context if available
             f"You are an AI assistant tasked with recommending study materials.\n"
             f"Provide a concise, high-quality list of recommended books, articles, or resources to help someone learn about '{topic}'.\n"
             f"Respond only in {self.user_language}. If resources in this language are limited, you may include a few English ones."
         )
         try:
             response = self.llm.invoke(prompt)
-            materials = response.content.split("\n")  # Each material expected on a new line
+            materials = [m for m in response.content.split("\n") if m]
             return materials
         except Exception as e:
             print(f"Error while generating materials for topic '{topic}': {e}")

--- a/QuizModule/quiz_operations.py
+++ b/QuizModule/quiz_operations.py
@@ -8,6 +8,7 @@ from langchain_openai import ChatOpenAI
 from langchain.schema.runnable import RunnableLambda, RunnableParallel
 from LearningPlanModule.learning_plan import LearningPlan
 from tools.auto_answer import auto_answer
+from tools.rag_service import RAGService
 
 
 def prepare_quiz_questions(subject: str, language: str = "en", retriever=None) -> list[dict]:
@@ -18,10 +19,14 @@ def prepare_quiz_questions(subject: str, language: str = "en", retriever=None) -
     """
     llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=0.1, verbose=True)
 
+    if retriever is None:
+        retriever = RAGService().get_retriever()
+
     context = ""
     if retriever:
-        docs = retriever.invoke(subject)
-        context = "\n\n".join([doc.page_content for doc in docs])
+        docs = retriever.get_relevant_documents(subject)
+        if docs:
+            context = "\n\n".join([doc.page_content for doc in docs])
 
     prompt_subject = subject
     if context:
@@ -44,11 +49,11 @@ def prepare_quiz_questions(subject: str, language: str = "en", retriever=None) -
 
     # Generate questions in parallel
     if retriever:
-        context_chain = RunnableLambda(
-            lambda inputs: "\n\n".join(
-                [doc.page_content for doc in retriever.invoke(inputs["topic"])]
-            )
-        )
+        def _topic_ctx(inputs):
+            docs = retriever.get_relevant_documents(inputs["topic"])
+            return "\n\n".join(doc.page_content for doc in docs) if docs else ""
+
+        context_chain = RunnableLambda(_topic_ctx)
         prompt_chain = RunnableLambda(
             lambda inputs: generate_questions_prompt(
                 inputs["topic"], language=language
@@ -56,7 +61,7 @@ def prepare_quiz_questions(subject: str, language: str = "en", retriever=None) -
         )
         question_chain = (
             RunnableParallel({"ctx": context_chain, "prompt": prompt_chain})
-            | RunnableLambda(lambda d: d["ctx"] + "\n\n" + d["prompt"].to_string())
+            | RunnableLambda(lambda d: (d["ctx"] + "\n\n" if d["ctx"] else "") + d["prompt"].to_string())
             | llm
         )
     else:
@@ -85,6 +90,9 @@ def generate_quiz(subject: str, language: str = "en", retriever=None):
     A ``retriever`` may be provided to enrich question prompts with additional
     context.
     """
+    if retriever is None:
+        retriever = RAGService().get_retriever()
+
     try:
         questions = prepare_quiz_questions(
             subject, language=language, retriever=retriever

--- a/SummaryModule/summary_generator.py
+++ b/SummaryModule/summary_generator.py
@@ -1,6 +1,7 @@
 from langchain_openai import ChatOpenAI
 from langchain_core.prompts import PromptTemplate
 from tools.language_handler import LanguageHandler
+from tools.rag_service import RAGService
 
 # TODO: optimize with pipeline, quering, give more detailed contents, maybe more examples :  with ML prompt there are no examples of algorithms ect.
 
@@ -13,6 +14,8 @@ class StudySummaryGenerator:
 
     def __init__(self, model_name="gpt-3.5-turbo", temperature=0.5, retriever=None):
         self.llm = ChatOpenAI(model=model_name, temperature=temperature)
+        if retriever is None:
+            retriever = RAGService().get_retriever()
         self.retriever = retriever  # optional document retriever
 
         self.base_prompt = PromptTemplate.from_template(
@@ -65,10 +68,13 @@ Respond in {language}.
         )
 
         retriever = retriever or self.retriever
+        if retriever is None:
+            retriever = RAGService().get_retriever()
         if retriever:
-            docs = retriever.invoke(input_text)
-            ctx = "\n\n".join([doc.page_content for doc in docs])
-            input_text = f"{ctx}\n\n### Topic:\n{input_text}"
+            docs = retriever.get_relevant_documents(input_text)
+            if docs:
+                ctx = "\n\n".join([doc.page_content for doc in docs])
+                input_text = f"{ctx}\n\n### Topic:\n{input_text}"
 
         chain = self.base_prompt | self.llm
         response = chain.invoke({"input": input_text, "language": lang})

--- a/tests/test_cheatsheet_generator.py
+++ b/tests/test_cheatsheet_generator.py
@@ -1,0 +1,28 @@
+import CheatSheetModule.cheatsheet_generator as cg
+from langchain.schema.runnable import Runnable
+
+
+class FakeLLM(Runnable):
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def invoke(self, prompt, config=None):
+        class Msg:
+            content = "cheatsheet"
+        return Msg()
+
+
+def test_generate_cheatsheet(monkeypatch):
+    class DummyRetriever:
+        def get_relevant_documents(self, query):
+            return []
+
+    class DummyService:
+        def get_retriever(self):
+            return DummyRetriever()
+
+    monkeypatch.setattr(cg, "ChatOpenAI", FakeLLM)
+    monkeypatch.setattr(cg, "RAGService", lambda: DummyService())
+    generator = cg.CheatSheetGenerator()
+    result = generator.generate_cheatsheet("topic")
+    assert result == "cheatsheet"

--- a/tests/test_flashcards.py
+++ b/tests/test_flashcards.py
@@ -19,7 +19,16 @@ class FakeLLM(Runnable):
 
 
 def test_generate_from_prompt(monkeypatch):
+    class DummyRetriever:
+        def get_relevant_documents(self, query):
+            return []
+
+    class DummyService:
+        def get_retriever(self):
+            return DummyRetriever()
+
     monkeypatch.setattr(fc, "ChatOpenAI", FakeLLM)
+    monkeypatch.setattr(fc, "RAGService", lambda: DummyService())
     flashcards = fc.FlashcardSet("geo")
     flashcards.generate_from_prompt("geography")
     assert flashcards.flashcards[0].question == "Capital of France?"
@@ -42,7 +51,11 @@ def test_generate_from_quiz_text():
         "d) Berlin\n"
         "Correct Answer: a"
     )
-    fs = fc.FlashcardSet("math")
+    class DummyRetriever:
+        def get_relevant_documents(self, query):
+            return []
+
+    fs = fc.FlashcardSet("math", retriever=DummyRetriever())
     fs.generate_from_quiz_text(raw)
     assert len(fs.flashcards) == 2
     assert fs.flashcards[0].question == "What is 2+2?"

--- a/tests/test_learning_plan.py
+++ b/tests/test_learning_plan.py
@@ -1,0 +1,28 @@
+import LearningPlanModule.learning_plan as lp
+from langchain.schema.runnable import Runnable
+
+
+class FakeLLM(Runnable):
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def invoke(self, prompt, config=None):
+        class Msg:
+            content = "Book1\nBook2"
+        return Msg()
+
+
+def test_recommend_materials(monkeypatch):
+    class DummyRetriever:
+        def get_relevant_documents(self, query):
+            return []
+
+    class DummyService:
+        def get_retriever(self):
+            return DummyRetriever()
+
+    monkeypatch.setattr(lp, "ChatOpenAI", FakeLLM)
+    monkeypatch.setattr(lp, "RAGService", lambda: DummyService())
+    plan = lp.LearningPlan("Alice")
+    materials = plan.recommend_materials("math")
+    assert materials == ["Book1", "Book2"]

--- a/tests/test_quiz_module.py
+++ b/tests/test_quiz_module.py
@@ -5,7 +5,7 @@ from QuizModule.quiz_operations import prepare_quiz_questions
 
 def test_prepare_quiz_questions_with_retriever(monkeypatch):
     class DummyRetriever:
-        def invoke(self, query):
+        def get_relevant_documents(self, query):
             assert query in {"subject", "topic1"}
             return [Document(page_content="context")]
 

--- a/tests/test_quiz_operations.py
+++ b/tests/test_quiz_operations.py
@@ -16,7 +16,16 @@ class FakeLLM(Runnable):
 
 
 def test_prepare_quiz_questions(monkeypatch):
+    class DummyRetriever:
+        def get_relevant_documents(self, query):
+            return []
+
+    class DummyService:
+        def get_retriever(self):
+            return DummyRetriever()
+
     monkeypatch.setattr(qo, "ChatOpenAI", FakeLLM)
+    monkeypatch.setattr(qo, "RAGService", lambda: DummyService())
     questions = qo.prepare_quiz_questions("math")
     assert questions == [
         {"topic": "Algebra", "question": "What is 2+2?", "correct": "a"},
@@ -38,5 +47,14 @@ class EmptyLLM(Runnable):
 
 
 def test_prepare_quiz_questions_no_topics(monkeypatch):
+    class DummyRetriever:
+        def get_relevant_documents(self, query):
+            return []
+
+    class DummyService:
+        def get_retriever(self):
+            return DummyRetriever()
+
     monkeypatch.setattr(qo, "ChatOpenAI", EmptyLLM)
+    monkeypatch.setattr(qo, "RAGService", lambda: DummyService())
     assert qo.prepare_quiz_questions("history") == []

--- a/tests/test_rag_service.py
+++ b/tests/test_rag_service.py
@@ -14,7 +14,7 @@ def test_ingest_and_retrieve(tmp_path):
     doc = Document(page_content="Cats are great pets")
     service.ingest_paths([doc])
     retriever = service.get_retriever()
-    docs = retriever.invoke("cats")
+    docs = retriever.get_relevant_documents("cats")
     assert any("Cats are great pets" in d.page_content for d in docs)
 
 
@@ -67,7 +67,7 @@ def test_ingest_pdf(tmp_path):
     service = RAGService(embeddings=FakeEmbeddings(size=32), persist_directory=str(tmp_path / "db3"))
     err = service.ingest_paths([str(pdf_path)])
     assert err is None
-    docs = service.get_retriever().invoke("cats")
+    docs = service.get_retriever().get_relevant_documents("cats")
     assert any("Cats are great pets" in d.page_content for d in docs)
 
 
@@ -79,5 +79,5 @@ def test_ingest_docx(tmp_path):
     service = RAGService(embeddings=FakeEmbeddings(size=32), persist_directory=str(tmp_path / "db4"))
     err = service.ingest_paths([str(docx_path)])
     assert err is None
-    docs = service.get_retriever().invoke("playful")
+    docs = service.get_retriever().get_relevant_documents("playful")
     assert any("Cats are playful animals" in d.page_content for d in docs)

--- a/tests/test_summary_generator.py
+++ b/tests/test_summary_generator.py
@@ -1,0 +1,28 @@
+import SummaryModule.summary_generator as sg
+from langchain.schema.runnable import Runnable
+
+
+class FakeLLM(Runnable):
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def invoke(self, prompt, config=None):
+        class Msg:
+            content = "summary"
+        return Msg()
+
+
+def test_generate_summary(monkeypatch):
+    class DummyRetriever:
+        def get_relevant_documents(self, query):
+            return []
+
+    class DummyService:
+        def get_retriever(self):
+            return DummyRetriever()
+
+    monkeypatch.setattr(sg, "ChatOpenAI", FakeLLM)
+    monkeypatch.setattr(sg, "RAGService", lambda: DummyService())
+    generator = sg.StudySummaryGenerator()
+    result = generator.generate_summary("topic")
+    assert result == "summary"


### PR DESCRIPTION
## Summary
- Default to `RAGService().get_retriever()` when no retriever is supplied in quiz, flashcard, summary, cheat sheet, and learning plan flows
- Skip context injection when `get_relevant_documents` returns no results
- Add tests covering default retriever behavior for summary, cheat sheet, and learning plan modules and update existing tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895f608987c83239e27299faabdc72d