### PR TITLE
Enable multi-query RAG with configurable MMR retrieval

### DIFF
--- a/CheatSheetModule/cheatsheet_generator.py
+++ b/CheatSheetModule/cheatsheet_generator.py
@@ -1,6 +1,9 @@
 from langchain_openai import ChatOpenAI
 from langchain_core.prompts import PromptTemplate
+import logging
 from tools.rag_service import RAGService
+
+logger = logging.getLogger(__name__)
 
 # TODO: test and optimize
 
@@ -51,7 +54,7 @@ Respond only in {language}.
         input_text: str,
         language: str = "en",
         retriever=None
-    ) -> str:
+    ) -> tuple[str, bool]:
         """
         Generate a cheat sheet with optional retrieved context.
 
@@ -68,13 +71,16 @@ Respond only in {language}.
             retriever = RAGService().get_retriever()
 
         ctx = ""
+        used_retriever = False
         # Perform retrieval-augmented generation only when a retriever is provided
         if retriever:
             docs = retriever.get_relevant_documents(input_text)
+            used_retriever = bool(docs)
             if docs:
                 ctx = "\n\n".join(d.page_content for d in docs)
+        logger.info("Cheat sheet generation used RAG: %s", used_retriever)
 
         response = (self.prompt | self.llm).invoke(
             {"input": input_text, "language": language, "context": ctx}
         )
-        return response.content
+        return response.content, used_retriever

--- a/FlashcardsModule/flashcards.py
+++ b/FlashcardsModule/flashcards.py
@@ -2,11 +2,14 @@ import json
 import os
 import re
 from datetime import datetime
+import logging
 
 from langchain.schema.runnable import RunnableLambda
 from langchain_openai import ChatOpenAI
 from tools.auto_answer import auto_answer
 from tools.rag_service import RAGService
+
+logger = logging.getLogger(__name__)
 
 
 class Flashcard:
@@ -78,10 +81,13 @@ class FlashcardSet:
             retriever = RAGService().get_retriever()
 
         ctx = ""
+        used_retriever = False
         if retriever:
             docs = retriever.get_relevant_documents(topic_prompt)
+            used_retriever = bool(docs)
             if docs:
                 ctx = "\n\n".join(d.page_content for d in docs)
+        logger.info("Flashcard generation used RAG: %s", used_retriever)
 
         def _build_prompt(inputs):
             context = inputs["context"]
@@ -129,6 +135,7 @@ class FlashcardSet:
             print(f"✅ Generated {len(self.flashcards)} flashcards from prompt.")
         except Exception as e:
             print(f"❌ Error generating flashcards from prompt: {e}")
+        return used_retriever
 
     def run_cli_review(self):
         """Simple CLI loop for reviewing the flashcards."""

--- a/QuizModule/quiz_operations.py
+++ b/QuizModule/quiz_operations.py
@@ -9,9 +9,14 @@ from langchain.schema.runnable import RunnableLambda, RunnableParallel
 from LearningPlanModule.learning_plan import LearningPlan
 from tools.auto_answer import auto_answer
 from tools.rag_service import RAGService
+import logging
+
+logger = logging.getLogger(__name__)
 
 
-def prepare_quiz_questions(subject: str, language: str = "en", retriever=None) -> list[dict]:
+def prepare_quiz_questions(
+    subject: str, language: str = "en", retriever=None
+) -> tuple[list[dict], bool]:
     """Return generated quiz questions.
 
     If a ``retriever`` is supplied, relevant context is fetched and appended to the
@@ -23,10 +28,13 @@ def prepare_quiz_questions(subject: str, language: str = "en", retriever=None) -
         retriever = RAGService().get_retriever()
 
     context = ""
+    used_retriever = False
     if retriever:
         docs = retriever.get_relevant_documents(subject)
+        used_retriever = bool(docs)
         if docs:
             context = "\n\n".join([doc.page_content for doc in docs])
+    logger.info("Quiz generation used RAG: %s", used_retriever)
 
     prompt_subject = subject
     if context:
@@ -37,13 +45,13 @@ def prepare_quiz_questions(subject: str, language: str = "en", retriever=None) -
     topic_result = llm.invoke(topic_prompt.format_prompt(subject=prompt_subject))
     topics = [t.strip() for t in topic_result.content.split("\n") if t.strip()]
     if not topics:
-        return []
+        return [], used_retriever
 
     max_questions = 20
     max_topics = min(len(topics), 5)
     topics = topics[:max_topics]
     if max_topics == 0:
-        return []
+        return [], used_retriever
 
     questions_per_topic = max_questions // max_topics
 
@@ -78,11 +86,15 @@ def prepare_quiz_questions(subject: str, language: str = "en", retriever=None) -
         q_texts = qset.content.split("\n\n")[:questions_per_topic]
         for q in q_texts:
             raw_correct = q.split("Correct Answer: ")[-1].strip().lower()
-            correct = raw_correct[0] if raw_correct and raw_correct[0] in ["a", "b", "c", "d"] else "?"
+            correct = (
+                raw_correct[0]
+                if raw_correct and raw_correct[0] in ["a", "b", "c", "d"]
+                else "?"
+            )
             text = q.rsplit("Correct Answer", 1)[0].strip()
             questions_list.append({"topic": topic, "question": text, "correct": correct})
 
-    return questions_list
+    return questions_list, used_retriever
 
 def generate_quiz(subject: str, language: str = "en", retriever=None):
     """Run an interactive quiz in the terminal and return the results.
@@ -94,12 +106,13 @@ def generate_quiz(subject: str, language: str = "en", retriever=None):
         retriever = RAGService().get_retriever()
 
     try:
-        questions = prepare_quiz_questions(
+        questions, used_retriever = prepare_quiz_questions(
             subject, language=language, retriever=retriever
         )
         if not questions:
             print("\u26a0\ufe0f No quiz topics generated.")
             return {}
+        logger.info("Interactive quiz used RAG: %s", used_retriever)
 
         print("\nStarting the quiz...\n")
         user_scores = {}

--- a/SummaryModule/summary_generator.py
+++ b/SummaryModule/summary_generator.py
@@ -1,7 +1,10 @@
 from langchain_openai import ChatOpenAI
 from langchain_core.prompts import PromptTemplate
+import logging
 from tools.language_handler import LanguageHandler
 from tools.rag_service import RAGService
+
+logger = logging.getLogger(__name__)
 
 # TODO: optimize with pipeline, quering, give more detailed contents, maybe more examples :  with ML prompt there are no examples of algorithms ect.
 
@@ -55,7 +58,7 @@ Respond in {language}.
 
     def generate_summary(
         self, input_text: str, language: str = "en", retriever=None
-    ) -> str:
+    ) -> tuple[str, bool]:
         """Generate a detailed study summary using the configured LLM and prompt.
 
         If a ``retriever`` is provided, it will be used to supply additional
@@ -70,12 +73,15 @@ Respond in {language}.
         retriever = retriever or self.retriever
         if retriever is None:
             retriever = RAGService().get_retriever()
+        used_retriever = False
         if retriever:
             docs = retriever.get_relevant_documents(input_text)
+            used_retriever = bool(docs)
             if docs:
                 ctx = "\n\n".join([doc.page_content for doc in docs])
                 input_text = f"{ctx}\n\n### Topic:\n{input_text}"
+        logger.info("Summary generation used RAG: %s", used_retriever)
 
         chain = self.base_prompt | self.llm
         response = chain.invoke({"input": input_text, "language": lang})
-        return response.content
+        return response.content, used_retriever

--- a/frontend_service/interface.py
+++ b/frontend_service/interface.py
@@ -198,7 +198,7 @@ def start_quiz(
     """Generate quiz questions and return the first one with state."""
     code = LanguageHandler.code_from_display(lang_choice)
     language = code if code != "auto" else LanguageHandler.choose_or_detect(subject)
-    questions = prepare_quiz_questions(
+    questions, used_retriever = prepare_quiz_questions(
         subject, language=language, retriever=retriever
     )
     if not questions:
@@ -212,7 +212,12 @@ def start_quiz(
         "correct_total": 0,
     }
     first_q = _format_question(questions[0])
-    return first_q, state, ""
+    notice = (
+        "📄 Quiz generated with document context"
+        if used_retriever
+        else "⚠️ Quiz generated without document context"
+    )
+    return first_q, state, notice
 
 
 def answer_quiz(choice: str, state: dict) -> tuple[str, dict, str]:
@@ -316,11 +321,17 @@ def run_flashcards_generate(
     flashcards = FlashcardSet(topic, retriever=retriever)
     buffer = io.StringIO()
     with redirect_stdout(buffer):
-        flashcards.generate_from_prompt(
+        used_retriever = flashcards.generate_from_prompt(
             topic_prompt=topic, language=language, retriever=retriever
         )
         path = flashcards.save_to_file()
     logs = buffer.getvalue()
+    notice = (
+        "📄 Flashcards generated with document context"
+        if used_retriever
+        else "⚠️ Flashcards generated without document context"
+    )
+    logs = notice + ("\n" + logs if logs else "")
     if path:
         logs += f"\nSaved to: {path}"
     cards = flashcards.to_dict_list()
@@ -390,7 +401,15 @@ def run_summary_interface(topic: str, lang_choice: str, retriever=None) -> str:
     code = LanguageHandler.code_from_display(lang_choice)
     language = code if code != "auto" else LanguageHandler.choose_or_detect(topic)
     summarizer = StudySummaryGenerator(retriever=retriever)
-    return summarizer.generate_summary(topic, language=language)
+    summary, used_retriever = summarizer.generate_summary(
+        topic, language=language, retriever=retriever
+    )
+    notice = (
+        "📄 Summary generated with document context"
+        if used_retriever
+        else "⚠️ Summary generated without document context"
+    )
+    return f"{notice}\n\n{summary}"
 
 
 def run_cheatsheet_interface(topic: str, lang_choice: str, retriever=None) -> str:
@@ -398,7 +417,15 @@ def run_cheatsheet_interface(topic: str, lang_choice: str, retriever=None) -> st
     code = LanguageHandler.code_from_display(lang_choice)
     language = code if code != "auto" else LanguageHandler.choose_or_detect(topic)
     generator = CheatSheetGenerator(retriever=retriever)
-    return generator.generate_cheatsheet(topic, language=language)
+    sheet, used_retriever = generator.generate_cheatsheet(
+        topic, language=language, retriever=retriever
+    )
+    notice = (
+        "📄 Cheat sheet generated with document context"
+        if used_retriever
+        else "⚠️ Cheat sheet generated without document context"
+    )
+    return f"{notice}\n\n{sheet}"
 
 
 def build_interface() -> gr.Blocks:

--- a/tests/test_cheatsheet_generator.py
+++ b/tests/test_cheatsheet_generator.py
@@ -24,5 +24,6 @@ def test_generate_cheatsheet(monkeypatch):
     monkeypatch.setattr(cg, "ChatOpenAI", FakeLLM)
     monkeypatch.setattr(cg, "RAGService", lambda: DummyService())
     generator = cg.CheatSheetGenerator()
-    result = generator.generate_cheatsheet("topic")
+    result, used = generator.generate_cheatsheet("topic")
     assert result == "cheatsheet"
+    assert used is False

--- a/tests/test_quiz_module.py
+++ b/tests/test_quiz_module.py
@@ -22,5 +22,6 @@ def test_prepare_quiz_questions_with_retriever(monkeypatch):
             return [Msg() for _ in prompts]
 
     monkeypatch.setattr("QuizModule.quiz_operations.ChatOpenAI", DummyLLM)
-    questions = prepare_quiz_questions("subject", retriever=DummyRetriever())
+    questions, used = prepare_quiz_questions("subject", retriever=DummyRetriever())
     assert questions == [{"topic": "topic1", "question": "Question?", "correct": "a"}]
+    assert used is True

--- a/tests/test_quiz_operations.py
+++ b/tests/test_quiz_operations.py
@@ -26,11 +26,12 @@ def test_prepare_quiz_questions(monkeypatch):
 
     monkeypatch.setattr(qo, "ChatOpenAI", FakeLLM)
     monkeypatch.setattr(qo, "RAGService", lambda: DummyService())
-    questions = qo.prepare_quiz_questions("math")
+    questions, used = qo.prepare_quiz_questions("math")
     assert questions == [
         {"topic": "Algebra", "question": "What is 2+2?", "correct": "a"},
         {"topic": "Geometry", "question": "What is 2+2?", "correct": "a"},
     ]
+    assert used is False
 
 
 class EmptyLLM(Runnable):
@@ -57,4 +58,6 @@ def test_prepare_quiz_questions_no_topics(monkeypatch):
 
     monkeypatch.setattr(qo, "ChatOpenAI", EmptyLLM)
     monkeypatch.setattr(qo, "RAGService", lambda: DummyService())
-    assert qo.prepare_quiz_questions("history") == []
+    qs, used = qo.prepare_quiz_questions("history")
+    assert qs == []
+    assert used is False

--- a/tests/test_rag_service.py
+++ b/tests/test_rag_service.py
@@ -10,7 +10,11 @@ from tools.rag_service import RAGService
 
 
 def test_ingest_and_retrieve(tmp_path):
-    service = RAGService(embeddings=FakeEmbeddings(size=32), persist_directory=str(tmp_path))
+    service = RAGService(
+        embeddings=FakeEmbeddings(size=32),
+        persist_directory=str(tmp_path),
+        use_multiquery=False,
+    )
     doc = Document(page_content="Cats are great pets")
     service.ingest_paths([doc])
     retriever = service.get_retriever()
@@ -25,7 +29,11 @@ def test_ingest_paths_lookup_error(monkeypatch, tmp_path, caplog):
     monkeypatch.setattr(UnstructuredFileLoader, "load", bad_load)
     file_path = tmp_path / "f.txt"
     file_path.write_text("test")
-    service = RAGService(embeddings=FakeEmbeddings(size=32), persist_directory=str(tmp_path / "db"))
+    service = RAGService(
+        embeddings=FakeEmbeddings(size=32),
+        persist_directory=str(tmp_path / "db"),
+        use_multiquery=False,
+    )
 
     caplog.set_level(logging.ERROR)
     msg = service.ingest_paths([str(file_path)])
@@ -40,7 +48,11 @@ def test_ingest_paths_import_error(monkeypatch, tmp_path, caplog):
     monkeypatch.setattr(UnstructuredFileLoader, "load", bad_load)
     file_path = tmp_path / "f.txt"
     file_path.write_text("test")
-    service = RAGService(embeddings=FakeEmbeddings(size=32), persist_directory=str(tmp_path / "db2"))
+    service = RAGService(
+        embeddings=FakeEmbeddings(size=32),
+        persist_directory=str(tmp_path / "db2"),
+        use_multiquery=False,
+    )
 
     caplog.set_level(logging.ERROR)
     msg = service.ingest_paths([str(file_path)])
@@ -64,7 +76,11 @@ def test_ingest_pdf(tmp_path):
     )
     pdf_path = tmp_path / "cats.pdf"
     pdf_path.write_bytes(base64.b64decode(pdf_b64))
-    service = RAGService(embeddings=FakeEmbeddings(size=32), persist_directory=str(tmp_path / "db3"))
+    service = RAGService(
+        embeddings=FakeEmbeddings(size=32),
+        persist_directory=str(tmp_path / "db3"),
+        use_multiquery=False,
+    )
     err = service.ingest_paths([str(pdf_path)])
     assert err is None
     docs = service.get_retriever().get_relevant_documents("cats")
@@ -76,7 +92,11 @@ def test_ingest_docx(tmp_path):
     doc = DocxDocument()
     doc.add_paragraph("Cats are playful animals")
     doc.save(docx_path)
-    service = RAGService(embeddings=FakeEmbeddings(size=32), persist_directory=str(tmp_path / "db4"))
+    service = RAGService(
+        embeddings=FakeEmbeddings(size=32),
+        persist_directory=str(tmp_path / "db4"),
+        use_multiquery=False,
+    )
     err = service.ingest_paths([str(docx_path)])
     assert err is None
     docs = service.get_retriever().get_relevant_documents("playful")

--- a/tests/test_summary_generator.py
+++ b/tests/test_summary_generator.py
@@ -24,5 +24,6 @@ def test_generate_summary(monkeypatch):
     monkeypatch.setattr(sg, "ChatOpenAI", FakeLLM)
     monkeypatch.setattr(sg, "RAGService", lambda: DummyService())
     generator = sg.StudySummaryGenerator()
-    result = generator.generate_summary("topic")
+    result, used = generator.generate_summary("topic")
     assert result == "summary"
+    assert used is False

--- a/tools/rag_service.py
+++ b/tools/rag_service.py
@@ -5,13 +5,16 @@ from __future__ import annotations
 from typing import Iterable, Optional, Tuple, Union
 
 import logging
+import os
 import shutil
 from hashlib import sha256
 
 from langchain_chroma import Chroma
 from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
-from langchain_openai import OpenAIEmbeddings
+from langchain_core.prompts import PromptTemplate
+from langchain.retrievers import MultiQueryRetriever
+from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 from langchain_community.document_loaders import (
     UnstructuredFileLoader,
     PyPDFLoader,
@@ -32,12 +35,35 @@ class RAGService:
         self,
         embeddings: Optional[Embeddings] = None,
         persist_directory: str = "data/chroma_db",
+        retriever_k: Optional[int] = None,
+        use_mmr: Optional[bool] = None,
+        use_multiquery: Optional[bool] = None,
+        mq_llm_model: Optional[str] = None,
+        mq_num_queries: Optional[int] = None,
+        mq_include_original: Optional[bool] = None,
     ) -> None:
         self._embeddings: Embeddings = embeddings or OpenAIEmbeddings()
         self._persist_directory = persist_directory
         self._vectorstore: Optional[Chroma] = None
         self._retriever = None
         self._retriever_params: Optional[Tuple[int, bool]] = None
+
+        # default retrieval parameters
+        self._default_k = retriever_k or int(os.getenv("RAG_K", 4))
+        env_mmr = os.getenv("RAG_USE_MMR")
+        self._default_mmr = (
+            use_mmr if use_mmr is not None else (env_mmr is None or env_mmr.lower() in {"1", "true", "yes"})
+        )
+        env_multi = os.getenv("RAG_USE_MULTIQUERY")
+        self._use_multiquery = (
+            use_multiquery if use_multiquery is not None else (env_multi is None or env_multi.lower() in {"1", "true", "yes"})
+        )
+        self._mq_llm_model = mq_llm_model or os.getenv("RAG_MQ_MODEL", "gpt-3.5-turbo")
+        self._mq_num_queries = mq_num_queries or int(os.getenv("RAG_MQ_NUM_QUERIES", 3))
+        env_inc = os.getenv("RAG_MQ_INCLUDE_ORIGINAL", "false")
+        self._mq_include_original = (
+            mq_include_original if mq_include_original is not None else env_inc.lower() in {"1", "true", "yes"}
+        )
 
     def _get_vectorstore(self) -> Chroma:
         """Return the underlying vector store, creating it if needed.
@@ -73,15 +99,39 @@ class RAGService:
                     )
         return self._vectorstore
 
-    def get_retriever(self, k: int = 4, mmr: bool = True):
+    def get_retriever(self, k: Optional[int] = None, mmr: Optional[bool] = None):
         """Return a cached retriever from the vector store."""
+        k = k or self._default_k
+        mmr = self._default_mmr if mmr is None else mmr
         params = (k, mmr)
         if self._retriever is None or self._retriever_params != params:
             search_type = "mmr" if mmr else "similarity"
-            self._retriever = self._get_vectorstore().as_retriever(
+            base = self._get_vectorstore().as_retriever(
                 search_type=search_type, search_kwargs={"k": k}
             )
             self._retriever_params = params
+            if self._use_multiquery:
+                try:
+                    llm = ChatOpenAI(model=self._mq_llm_model, temperature=0)
+                    prompt = PromptTemplate.from_template(
+                        "You are an AI language model assistant. Your task is \n    to generate {n} different versions of the given user \n    question to retrieve relevant documents from a vector  database. \n    By generating multiple perspectives on the user question, \n    your goal is to help the user overcome some of the limitations \n    of distance-based similarity search. Provide these alternative \n    questions separated by newlines. Original question: {question}".replace(
+                            "{n}", str(self._mq_num_queries)
+                        )
+                    )
+                    self._retriever = MultiQueryRetriever.from_llm(
+                        retriever=base,
+                        llm=llm,
+                        prompt=prompt,
+                        include_original=self._mq_include_original,
+                    )
+                    logger.info(
+                        "Initialized MultiQueryRetriever with model %s", self._mq_llm_model
+                    )
+                except Exception as exc:  # pragma: no cover - network issues
+                    logger.warning("MultiQueryRetriever unavailable: %s", exc)
+                    self._retriever = base
+            else:
+                self._retriever = base
         return self._retriever
 
     def ingest_paths(self, items: Iterable[Union[str, Document]]) -> Optional[str]:


### PR DESCRIPTION
## Summary
- Wrap Chroma retriever with MultiQueryRetriever and default to MMR search
- Expose RAG tuning parameters via env vars/kwargs and log RAG usage across modules
- Indicate RAG usage in quiz, flashcard, summary and cheat sheet UI outputs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895fef18d3c83238488608745b4e6c2