### PR TITLE
Add RAG context fallback when no documents found

### DIFF
--- a/AgentModule/edu_agent.py
+++ b/AgentModule/edu_agent.py
@@ -6,6 +6,7 @@ from langchain_core.prompts import PromptTemplate
 from langchain.tools import tool
 
 from tools.rag_service import RAGService
+from tools.rag_utils import get_context_or_empty
 from tools.edu_tools import (
     wikipedia_search,
     define_word,
@@ -21,8 +22,7 @@ def rag_search(query: str) -> str:
     """Retrieve relevant document chunks using the RAG service."""
     try:
         retriever = RAGService().get_retriever()
-        docs = retriever.invoke(query)
-        return "\n\n".join(doc.page_content for doc in docs)
+        return get_context_or_empty(query, retriever)
     except Exception as e:  # pragma: no cover - retrieval errors
         return f"RAG search error: {e}"
 
@@ -89,15 +89,11 @@ def run_agent(
 
     used_retriever = False
     if retriever:
-        try:
-            docs = retriever.invoke(question)
-            if docs:
-                context = "\n\n".join(doc.page_content for doc in docs)
-                question = f"{question}\n\nContext:\n{context}"
-                used_retriever = True
-            logging.getLogger(__name__).info("Retrieved %d doc(s)", len(docs))
-        except Exception as e:  # pragma: no cover - retrieval errors
-            logging.getLogger(__name__).warning("Retrieval failed: %s", e)
+        context = get_context_or_empty(question, retriever)
+        if context:
+            question = f"{question}\n\nContext:\n{context}"
+            used_retriever = True
+            logging.getLogger(__name__).info("Retrieved context for query")
 
     lang = LanguageHandler.choose_or_detect(question)
     try:

--- a/CheatSheetModule/cheatsheet_generator.py
+++ b/CheatSheetModule/cheatsheet_generator.py
@@ -2,6 +2,7 @@ from langchain_openai import ChatOpenAI
 from langchain_core.prompts import PromptTemplate
 import logging
 from tools.rag_service import RAGService
+from tools.rag_utils import get_context_or_empty
 
 logger = logging.getLogger(__name__)
 
@@ -70,14 +71,8 @@ Respond only in {language}.
         if retriever is None:
             retriever = RAGService().get_retriever()
 
-        ctx = ""
-        used_retriever = False
-        # Perform retrieval-augmented generation only when a retriever is provided
-        if retriever:
-            docs = retriever.get_relevant_documents(input_text)
-            used_retriever = bool(docs)
-            if docs:
-                ctx = "\n\n".join(d.page_content for d in docs)
+        ctx = get_context_or_empty(input_text, retriever)
+        used_retriever = bool(ctx)
         logger.info("Cheat sheet generation used RAG: %s", used_retriever)
 
         response = (self.prompt | self.llm).invoke(

--- a/FlashcardsModule/flashcards.py
+++ b/FlashcardsModule/flashcards.py
@@ -8,6 +8,7 @@ from langchain.schema.runnable import RunnableLambda
 from langchain_openai import ChatOpenAI
 from tools.auto_answer import auto_answer
 from tools.rag_service import RAGService
+from tools.rag_utils import get_context_or_empty
 
 logger = logging.getLogger(__name__)
 
@@ -80,13 +81,8 @@ class FlashcardSet:
         if retriever is None:
             retriever = RAGService().get_retriever()
 
-        ctx = ""
-        used_retriever = False
-        if retriever:
-            docs = retriever.get_relevant_documents(topic_prompt)
-            used_retriever = bool(docs)
-            if docs:
-                ctx = "\n\n".join(d.page_content for d in docs)
+        ctx = get_context_or_empty(topic_prompt, retriever)
+        used_retriever = bool(ctx)
         logger.info("Flashcard generation used RAG: %s", used_retriever)
 
         def _build_prompt(inputs):

--- a/LearningPlanModule/learning_plan.py
+++ b/LearningPlanModule/learning_plan.py
@@ -3,6 +3,7 @@ import os
 from datetime import date, timedelta, datetime
 from langchain_openai import ChatOpenAI
 from tools.rag_service import RAGService
+from tools.rag_utils import get_context_or_empty
 
 # TODO: use cases from prompts for edu
 
@@ -93,11 +94,9 @@ class LearningPlan:
         if retriever is None:
             retriever = RAGService().get_retriever()
 
-        ctx = ""
-        if retriever:
-            docs = retriever.get_relevant_documents(topic)
-            if docs:
-                ctx = "\n\n".join(d.page_content for d in docs) + "\n\n"
+        ctx = get_context_or_empty(topic, retriever)
+        if ctx:
+            ctx += "\n\n"
 
         prompt = (
             f"{ctx}"  # prepend context if available

--- a/QuizModule/quiz_operations.py
+++ b/QuizModule/quiz_operations.py
@@ -9,6 +9,7 @@ from langchain.schema.runnable import RunnableLambda, RunnableParallel
 from LearningPlanModule.learning_plan import LearningPlan
 from tools.auto_answer import auto_answer
 from tools.rag_service import RAGService
+from tools.rag_utils import get_context_or_empty
 import logging
 
 logger = logging.getLogger(__name__)
@@ -27,13 +28,8 @@ def prepare_quiz_questions(
     if retriever is None:
         retriever = RAGService().get_retriever()
 
-    context = ""
-    used_retriever = False
-    if retriever:
-        docs = retriever.get_relevant_documents(subject)
-        used_retriever = bool(docs)
-        if docs:
-            context = "\n\n".join([doc.page_content for doc in docs])
+    context = get_context_or_empty(subject, retriever)
+    used_retriever = bool(context)
     logger.info("Quiz generation used RAG: %s", used_retriever)
 
     prompt_subject = subject
@@ -58,8 +54,7 @@ def prepare_quiz_questions(
     # Generate questions in parallel
     if retriever:
         def _topic_ctx(inputs):
-            docs = retriever.get_relevant_documents(inputs["topic"])
-            return "\n\n".join(doc.page_content for doc in docs) if docs else ""
+            return get_context_or_empty(inputs["topic"], retriever)
 
         context_chain = RunnableLambda(_topic_ctx)
         prompt_chain = RunnableLambda(

--- a/SummaryModule/summary_generator.py
+++ b/SummaryModule/summary_generator.py
@@ -3,6 +3,7 @@ from langchain_core.prompts import PromptTemplate
 import logging
 from tools.language_handler import LanguageHandler
 from tools.rag_service import RAGService
+from tools.rag_utils import get_context_or_empty
 
 logger = logging.getLogger(__name__)
 
@@ -73,13 +74,11 @@ Respond in {language}.
         retriever = retriever or self.retriever
         if retriever is None:
             retriever = RAGService().get_retriever()
-        used_retriever = False
-        if retriever:
-            docs = retriever.get_relevant_documents(input_text)
-            used_retriever = bool(docs)
-            if docs:
-                ctx = "\n\n".join([doc.page_content for doc in docs])
-                input_text = f"{ctx}\n\n### Topic:\n{input_text}"
+
+        ctx = get_context_or_empty(input_text, retriever)
+        used_retriever = bool(ctx)
+        if ctx:
+            input_text = f"{ctx}\n\n### Topic:\n{input_text}"
         logger.info("Summary generation used RAG: %s", used_retriever)
 
         chain = self.base_prompt | self.llm

--- a/tests/test_edu_agent.py
+++ b/tests/test_edu_agent.py
@@ -37,7 +37,7 @@ def test_rag_search(monkeypatch):
     class DummyRetriever:
         def invoke(self, query):
             assert query == "cats"
-            return [Document(page_content="one"), Document(page_content="two")]
+            return [Document(page_content="cats one"), Document(page_content="cats two")]
 
     class DummyService:
         def get_retriever(self):
@@ -45,7 +45,7 @@ def test_rag_search(monkeypatch):
 
     monkeypatch.setattr(ea, "RAGService", lambda: DummyService())
     result = ea.rag_search("cats")
-    assert result == "one\n\ntwo"
+    assert result == "cats one\n\ncats two"
 
 
 def test_create_agent_includes_rag_search(monkeypatch):
@@ -98,7 +98,7 @@ def test_run_agent_injects_retriever_context(monkeypatch):
     class DummyRetriever:
         def invoke(self, query):
             assert query == "Question"
-            return [Document(page_content="context from retriever")]
+            return [Document(page_content="context from retriever about question")]
 
     monkeypatch.setattr(lh.LanguageHandler, "choose_or_detect", lambda text: "en")
     monkeypatch.setattr(lh.LanguageHandler, "ensure_language", lambda text, lang: text)

--- a/tests/test_quiz_module.py
+++ b/tests/test_quiz_module.py
@@ -7,15 +7,17 @@ def test_prepare_quiz_questions_with_retriever(monkeypatch):
     class DummyRetriever:
         def get_relevant_documents(self, query):
             assert query in {"subject", "topic1"}
-            return [Document(page_content="context")]
+            return [Document(page_content="subject related context")]
 
     class DummyLLM(Runnable):
         def __init__(self, *args, **kwargs):
             super().__init__()
+
         def invoke(self, prompt, **kwargs):
             class Msg:
                 content = "topic1"
             return Msg()
+
         def batch(self, prompts, config=None, **kwargs):
             class Msg:
                 content = "Question?\nCorrect Answer: a"
@@ -25,3 +27,30 @@ def test_prepare_quiz_questions_with_retriever(monkeypatch):
     questions, used = prepare_quiz_questions("subject", retriever=DummyRetriever())
     assert questions == [{"topic": "topic1", "question": "Question?", "correct": "a"}]
     assert used is True
+
+
+def test_prepare_quiz_questions_ignores_irrelevant_context(monkeypatch):
+    class DummyRetriever:
+        def get_relevant_documents(self, query):
+            assert query in {"subject", "topic1"}
+            return [Document(page_content="quantum fractal fusion data")]
+
+    class DummyLLM(Runnable):
+        def __init__(self, *args, **kwargs):
+            super().__init__()
+
+        def invoke(self, prompt, **kwargs):
+            class Msg:
+                content = "topic1"
+            return Msg()
+
+        def batch(self, prompts, config=None, **kwargs):
+            class Msg:
+                content = "Question?\nCorrect Answer: a"
+            return [Msg() for _ in prompts]
+
+    monkeypatch.setattr("QuizModule.quiz_operations.ChatOpenAI", DummyLLM)
+    questions, used = prepare_quiz_questions("subject", retriever=DummyRetriever())
+    assert questions == [{"topic": "topic1", "question": "Question?", "correct": "a"}]
+    assert used is False
+

--- a/tests/test_rag_utils.py
+++ b/tests/test_rag_utils.py
@@ -1,5 +1,4 @@
 from langchain_core.documents import Document
-
 from tools.rag_utils import get_context_or_empty
 
 
@@ -23,3 +22,9 @@ def test_get_context_or_empty_handles_empty():
 
 def test_get_context_or_empty_none_retriever():
     assert get_context_or_empty("q", None) == ""
+
+
+def test_get_context_or_empty_filters_irrelevant():
+    retriever = DummyRetriever([Document(page_content="quantum physics notes")])
+    assert get_context_or_empty("art history", retriever) == ""
+

--- a/tests/test_rag_utils.py
+++ b/tests/test_rag_utils.py
@@ -1,0 +1,25 @@
+from langchain_core.documents import Document
+
+from tools.rag_utils import get_context_or_empty
+
+
+class DummyRetriever:
+    def __init__(self, docs):
+        self._docs = docs
+
+    def get_relevant_documents(self, query):
+        return self._docs
+
+
+def test_get_context_or_empty_returns_joined():
+    retriever = DummyRetriever([Document(page_content="a"), Document(page_content="b")])
+    assert get_context_or_empty("q", retriever) == "a\n\nb"
+
+
+def test_get_context_or_empty_handles_empty():
+    retriever = DummyRetriever([])
+    assert get_context_or_empty("q", retriever) == ""
+
+
+def test_get_context_or_empty_none_retriever():
+    assert get_context_or_empty("q", None) == ""

--- a/tools/rag_utils.py
+++ b/tools/rag_utils.py
@@ -3,16 +3,17 @@
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any
 
 
 def get_context_or_empty(query: str, retriever: Any | None) -> str:
     """Return joined page contents for ``query`` using ``retriever``.
 
-    If ``retriever`` is ``None``, retrieval fails, or no documents are found,
-    an empty string is returned. This centralizes the "no documents" fallback
-    behaviour so callers only append context when this function returns
-    non-empty text.
+    If ``retriever`` is ``None``, retrieval fails, or no relevant documents are
+    found, an empty string is returned. Retrieved documents are considered
+    relevant only if they share at least one non-trivial word with the query so
+    that unrelated RAG content does not override the user's request.
     """
     if not retriever:
         return ""
@@ -29,4 +30,16 @@ def get_context_or_empty(query: str, retriever: Any | None) -> str:
     if not docs:
         return ""
 
-    return "\n\n".join(getattr(d, "page_content", str(d)) for d in docs)
+    # Build a set of meaningful query words (length >= 3) to check relevance.
+    keywords = set(re.findall(r"\b\w{3,}\b", query.lower()))
+    relevant_contents = []
+    for doc in docs:
+        text = getattr(doc, "page_content", str(doc))
+        lower = text.lower()
+        if not keywords or any(word in lower for word in keywords):
+            relevant_contents.append(text)
+
+    if not relevant_contents:
+        return ""
+
+    return "\n\n".join(relevant_contents)

--- a/tools/rag_utils.py
+++ b/tools/rag_utils.py
@@ -1,0 +1,32 @@
+"""Helper utilities for retrieval-augmented generation."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+
+def get_context_or_empty(query: str, retriever: Any | None) -> str:
+    """Return joined page contents for ``query`` using ``retriever``.
+
+    If ``retriever`` is ``None``, retrieval fails, or no documents are found,
+    an empty string is returned. This centralizes the "no documents" fallback
+    behaviour so callers only append context when this function returns
+    non-empty text.
+    """
+    if not retriever:
+        return ""
+
+    try:
+        if hasattr(retriever, "get_relevant_documents"):
+            docs = retriever.get_relevant_documents(query)
+        else:
+            docs = retriever.invoke(query)
+    except Exception as exc:  # pragma: no cover - retrieval errors
+        logging.getLogger(__name__).warning("Retrieval failed: %s", exc)
+        return ""
+
+    if not docs:
+        return ""
+
+    return "\n\n".join(getattr(d, "page_content", str(d)) for d in docs)


### PR DESCRIPTION
## Summary
- Add `get_context_or_empty` helper to centralize RAG context retrieval and return an empty string when no documents are found
- Refactor agent, flashcard, quiz, summary, cheat sheet and learning plan modules to use this helper and only append document context when present
- Display context-used notices only when relevant documents exist

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896067357508323b7bfe550e624e16c