### PR TITLE
Ensure quiz topics override unrelated RAG context

### DIFF
--- a/tests/test_edu_agent.py
+++ b/tests/test_edu_agent.py
@@ -37,7 +37,7 @@ def test_rag_search(monkeypatch):
     class DummyRetriever:
         def invoke(self, query):
             assert query == "cats"
-            return [Document(page_content="one"), Document(page_content="two")]
+            return [Document(page_content="cats one"), Document(page_content="cats two")]
 
     class DummyService:
         def get_retriever(self):
@@ -45,7 +45,7 @@ def test_rag_search(monkeypatch):
 
     monkeypatch.setattr(ea, "RAGService", lambda: DummyService())
     result = ea.rag_search("cats")
-    assert result == "one\n\ntwo"
+    assert result == "cats one\n\ncats two"
 
 
 def test_create_agent_includes_rag_search(monkeypatch):
@@ -98,7 +98,7 @@ def test_run_agent_injects_retriever_context(monkeypatch):
     class DummyRetriever:
         def invoke(self, query):
             assert query == "Question"
-            return [Document(page_content="context from retriever")]
+            return [Document(page_content="context from retriever about question")]
 
     monkeypatch.setattr(lh.LanguageHandler, "choose_or_detect", lambda text: "en")
     monkeypatch.setattr(lh.LanguageHandler, "ensure_language", lambda text, lang: text)

--- a/tests/test_quiz_module.py
+++ b/tests/test_quiz_module.py
@@ -7,15 +7,17 @@ def test_prepare_quiz_questions_with_retriever(monkeypatch):
     class DummyRetriever:
         def get_relevant_documents(self, query):
             assert query in {"subject", "topic1"}
-            return [Document(page_content="context")]
+            return [Document(page_content="subject related context")]
 
     class DummyLLM(Runnable):
         def __init__(self, *args, **kwargs):
             super().__init__()
+
         def invoke(self, prompt, **kwargs):
             class Msg:
                 content = "topic1"
             return Msg()
+
         def batch(self, prompts, config=None, **kwargs):
             class Msg:
                 content = "Question?\nCorrect Answer: a"
@@ -25,3 +27,30 @@ def test_prepare_quiz_questions_with_retriever(monkeypatch):
     questions, used = prepare_quiz_questions("subject", retriever=DummyRetriever())
     assert questions == [{"topic": "topic1", "question": "Question?", "correct": "a"}]
     assert used is True
+
+
+def test_prepare_quiz_questions_ignores_irrelevant_context(monkeypatch):
+    class DummyRetriever:
+        def get_relevant_documents(self, query):
+            assert query in {"subject", "topic1"}
+            return [Document(page_content="quantum fractal fusion data")]
+
+    class DummyLLM(Runnable):
+        def __init__(self, *args, **kwargs):
+            super().__init__()
+
+        def invoke(self, prompt, **kwargs):
+            class Msg:
+                content = "topic1"
+            return Msg()
+
+        def batch(self, prompts, config=None, **kwargs):
+            class Msg:
+                content = "Question?\nCorrect Answer: a"
+            return [Msg() for _ in prompts]
+
+    monkeypatch.setattr("QuizModule.quiz_operations.ChatOpenAI", DummyLLM)
+    questions, used = prepare_quiz_questions("subject", retriever=DummyRetriever())
+    assert questions == [{"topic": "topic1", "question": "Question?", "correct": "a"}]
+    assert used is False
+

--- a/tests/test_rag_utils.py
+++ b/tests/test_rag_utils.py
@@ -1,5 +1,4 @@
 from langchain_core.documents import Document
-
 from tools.rag_utils import get_context_or_empty
 
 
@@ -23,3 +22,9 @@ def test_get_context_or_empty_handles_empty():
 
 def test_get_context_or_empty_none_retriever():
     assert get_context_or_empty("q", None) == ""
+
+
+def test_get_context_or_empty_filters_irrelevant():
+    retriever = DummyRetriever([Document(page_content="quantum physics notes")])
+    assert get_context_or_empty("art history", retriever) == ""
+

--- a/tools/rag_utils.py
+++ b/tools/rag_utils.py
@@ -3,16 +3,17 @@
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any
 
 
 def get_context_or_empty(query: str, retriever: Any | None) -> str:
     """Return joined page contents for ``query`` using ``retriever``.
 
-    If ``retriever`` is ``None``, retrieval fails, or no documents are found,
-    an empty string is returned. This centralizes the "no documents" fallback
-    behaviour so callers only append context when this function returns
-    non-empty text.
+    If ``retriever`` is ``None``, retrieval fails, or no relevant documents are
+    found, an empty string is returned. Retrieved documents are considered
+    relevant only if they share at least one non-trivial word with the query so
+    that unrelated RAG content does not override the user's request.
     """
     if not retriever:
         return ""
@@ -29,4 +30,16 @@ def get_context_or_empty(query: str, retriever: Any | None) -> str:
     if not docs:
         return ""
 
-    return "\n\n".join(getattr(d, "page_content", str(d)) for d in docs)
+    # Build a set of meaningful query words (length >= 3) to check relevance.
+    keywords = set(re.findall(r"\b\w{3,}\b", query.lower()))
+    relevant_contents = []
+    for doc in docs:
+        text = getattr(doc, "page_content", str(doc))
+        lower = text.lower()
+        if not keywords or any(word in lower for word in keywords):
+            relevant_contents.append(text)
+
+    if not relevant_contents:
+        return ""
+
+    return "\n\n".join(relevant_contents)


### PR DESCRIPTION
## Summary
- ignore retrieved documents with no keyword overlap to prevent irrelevant RAG content from influencing quiz generation
- add tests covering context filtering and updated quiz behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68960f8a9fd88323ac5da89f5c3a74dd